### PR TITLE
Increase recent games page size 30 -> 50 (jp + hk)

### DIFF
--- a/backend/src/services/game/hongKongGame.service.ts
+++ b/backend/src/services/game/hongKongGame.service.ts
@@ -172,7 +172,7 @@ class HongKongGameService extends GameService {
             orderBy: {
                 createdAt: "desc",
             },
-            take: 30,
+            take: 50,
         });
 
         return games

--- a/backend/src/services/game/japaneseGame.service.ts
+++ b/backend/src/services/game/japaneseGame.service.ts
@@ -270,7 +270,7 @@ class JapaneseGameService extends GameService {
             orderBy: {
                 createdAt: "desc",
             },
-            take: 30,
+            take: 50,
         });
 
         return games


### PR DESCRIPTION
Return the 50 most recent games per variant instead of 30, matching the redesigned Games page which surfaces more history. Symmetric change across both variant services; no other behavior affected.