### PR TITLE
Add design-system foundation (tokens, theming, accent, color scheme)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,353 @@
+# DESIGN.md — UI/UX & Responsive Guidelines for Claude
+
+This file is the design source-of-truth for **Claude Code** when building or changing
+UI in this repo (React + TypeScript + Vite + **Material-UI v7**, **dark theme only**).
+Read it before touching anything visual. Rules are imperative on purpose — follow them
+unless the user explicitly overrides.
+
+It distills MUI's [Responsive UI guide](https://mui.com/material-ui/guides/responsive-ui/)
+(Grid, Container, Breakpoints, `useMediaQuery`) and was cross-checked against a UI/UX
+rule set (accessibility, touch, performance, layout, typography, animation). The current
+theme tokens and config are embedded at the bottom as the single reference.
+
+---
+
+## 0. How to use this file
+
+- **Style with the theme, not hardcoded values.** Import tokens from `@/theme/tokens`,
+  reuse `sx` presets from `@/theme/utils`, and rely on the component overrides in
+  `@/theme` (`createAppTheme`). Never paste raw hex/rgba into a component.
+- **Match the surrounding file.** Existing code is `any`-free, uses the `sx` prop, and
+  responsive objects — keep that idiom.
+- **When in doubt, mobile-first + CSS-first.** Default base styles to `xs`, layer larger
+  breakpoints on top, and prefer responsive `sx` over JS branching.
+
+---
+
+## 1. Core principles
+
+1. **Mobile-first.** Write the `xs` (smallest) case as the base, then add `sm`/`md`/`lg`
+   overrides that *enlarge*. Use `theme.breakpoints.up(key)` in styled/CSS contexts.
+2. **CSS-first responsiveness.** Use the `sx` prop's responsive object syntax for layout
+   and styling. Only reach for `useMediaQuery` when you must **conditionally render**
+   different React (e.g. swap a `Dialog` for a `Drawer`, toggle DataGrid `density`),
+   never for styling that CSS can express.
+3. **Token discipline.** All color/shadow/timing/gradient values come from
+   `@/theme/tokens`. If you need a new value, add a token there first.
+4. **Consistency over novelty.** Reuse existing components, spacing rhythm, and the
+   established radius/shadow scale. Uniform elements + spacing = the MUI/Material baseline.
+5. **Accessibility is not optional.** Contrast, focus, keyboard, labels, reduced-motion
+   are CRITICAL — see §8.
+
+---
+
+## 2. Breakpoints (MUI defaults — do not change)
+
+| key | min width | typical device |
+|-----|-----------|----------------|
+| `xs` | 0px    | phones |
+| `sm` | 600px  | large phones / small tablets |
+| `md` | 900px  | tablets / small laptops |
+| `lg` | 1200px | laptops / desktops |
+| `xl` | 1536px | large desktops |
+
+- Always reference breakpoints by **named key**, never magic pixels.
+- Responsive object syntax (preferred):
+  ```tsx
+  <Box sx={{ py: { xs: 4, md: 7 }, fontSize: { xs: "1rem", md: "1.15rem" } }} />
+  <Stack direction={{ xs: "column", sm: "row" }} spacing={{ xs: 2, md: 3 }} />
+  ```
+- In `styled()`/theme overrides use helpers: `theme.breakpoints.up("md")`,
+  `.down()`, `.between(a, b)`, `.only()`.
+- `useMediaQuery` only for render logic:
+  ```tsx
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  // density / Dialog-vs-Drawer / tap-vs-doubleclick — not styling
+  ```
+
+---
+
+## 3. Layout
+
+- **`Container`** centers content and applies responsive gutters (already themed: 16px,
+  24px ≥md). Use `maxWidth="lg"` for page content; one Container per content band.
+- **`Stack`** for 1-D flows. Use `direction={{ xs: "column", sm: "row" }}` to stack on
+  mobile and row on larger screens. Add `useFlexGap flexWrap="wrap"` when items should
+  wrap instead of overflow.
+- **`Grid`** (v7 `size={{ xs, md }}`) for 2-D responsive layouts.
+- **No horizontal scroll** on any breakpoint. Test at **375px** width. Use `minWidth: 0`
+  on flex children that contain text so they can shrink/ellipsize instead of overflowing.
+- **Full-bleed sections** (e.g. hero): a full-width wrapper with an inner `Container`.
+- **Respect safe areas** for fixed/sticky UI: pad with `env(safe-area-inset-*)`
+  (the NavBar drawer and Game footer already do this).
+- **Fixed/sticky bars must reserve space** so content isn't hidden beneath them
+  (see Game.tsx footer padding via `--game-footer-height`).
+
+---
+
+## 4. Spacing & sizing
+
+- **8px spacing scale** (theme `spacing: 8`). `spacing={2}` = 16px. Use the scale for
+  padding/margins/gaps — no arbitrary px.
+- Vertical rhythm tiers: ~16 / 24 / 32 / 48 (`2 / 3 / 4 / 6`) by hierarchy level.
+- **Touch targets ≥ 44px.** Already enforced for `MuiButton`, `MuiIconButton`
+  (min 44). Keep custom interactive elements ≥44px and ≥8px apart.
+- **Use `100dvh`, not `100vh`** for full-height mobile (accounts for browser chrome).
+  See `responsiveDataGridContainer`.
+- Declare image/media dimensions (`width`/`height` or `aspectRatio`) to avoid layout
+  shift (CLS).
+
+---
+
+## 5. Typography
+
+- The theme scale (h1–h6, body1/2, caption) is in `@/theme`. Prefer `variant=` over
+  custom font sizes; if you need fluid sizing, use `clamp()` (h1–h3 already do).
+- Responsive font size via objects when needed: `fontSize: { xs: "1rem", md: "1.15rem" }`.
+- **Body line-height 1.5–1.75**; **line length ~60–75 chars** on desktop (cap text
+  blocks with `maxWidth` ~ 60ch / 520–640px).
+- **Tabular numerals for data** (leaderboard ELO, scores, timers):
+  `fontVariantNumeric: "tabular-nums"` to prevent column jitter.
+- **Inputs must render ≥16px on mobile** — fonts < 16px trigger iOS auto-zoom on focus.
+  ✅ Handled globally: the `MuiTextField` override forces input font to `16px` below `sm`
+  (compact `0.9rem` on ≥sm). `Autocomplete`/`Select` inherit this via `TextField`, so you
+  normally don't need a per-field override. Only override if you build an input that does
+  **not** go through `TextField`.
+- Weight for hierarchy: headings 700–800, labels 500–600, body 400.
+- Prefer wrapping over truncation; if truncating, provide full text via tooltip.
+
+---
+
+## 6. Color & theming (dark mode)
+
+- **Dark mode is the only mode.** Design and verify against the dark surfaces below.
+- **Never hardcode colors.** Use `theme.palette.*` (`primary.main/light/dark`,
+  `text.primary/secondary`, `background.default/paper`, `divider`) or tokens from
+  `@/theme/tokens` (`surface`, `overlay`, `shadow`, `gradient`, `placement`, `palette.medal`).
+- **Contrast (WCAG AA):** body text ≥ **4.5:1**, large/secondary text ≥ **3:1**,
+  UI glyphs/borders ≥ 3:1. Verify new foreground/background pairs.
+- **Never use color as the only signal.** Pair status color with an icon/label
+  (e.g. chombo chip, live dot, placement medals all carry shape/text too).
+- **Dividers/borders** are light-on-dark (`overlay.dark.border`) so they stay visible —
+  keep using the token, don't invent dark borders that vanish.
+- **Modal/overlay scrim 40–60% black** to isolate foreground (`overlay.dark.overlay`).
+- **Gradients:** when a gradient direction is responsive, **keep its anchor consistent
+  across breakpoints.** Do not flip a left-anchored scrim to vertical/right at a smaller
+  breakpoint (this caused a real hero bug — the dark side appeared to jump). Prefer one
+  direction that holds at all widths.
+
+---
+
+## 7. Interaction & animation
+
+- **Hover only on hover-capable devices.** Guard hover transforms with
+  `@media (hover: hover)` (theme already does this for Button/IconButton). On touch, a
+  bare `:hover` transform latches after a tap.
+- **Press feedback** within ~100ms; keep `:active` states.
+- **Timing:** micro-interactions **150–300ms**; use the `timing` tokens
+  (`fast 0.12s`, `normal 0.18s`, `slow 0.22s`, `ease` cubic-bezier). Avoid > 500ms.
+- **Animate `transform`/`opacity` only** (never width/height/top/left) to avoid reflow.
+- **Exit faster than enter** (~60–70%). Ease-out entering, ease-in exiting.
+- **Respect `prefers-reduced-motion`** — gate non-essential motion:
+  ```tsx
+  sx={{ "@media (prefers-reduced-motion: reduce)": { transition: "none", animation: "none" } }}
+  ```
+- Reuse `responsiveCardHover` for card hover affordances (it already disables lift on `xs`).
+
+---
+
+## 8. Accessibility (CRITICAL — verify every change)
+
+- **Contrast** meets §6 thresholds.
+- **Visible focus rings** — never remove `:focus-visible` outlines; the theme adds a
+  focus ring on inputs (`overlay.primary.focus`). Custom controls need a focus indicator.
+- **Icon-only buttons need `aria-label`** (or visually-hidden text).
+- **Keyboard:** everything operable by keyboard; tab order matches visual order;
+  don't trap focus except in modals (which must offer Esc/close).
+- **Headings sequential** (h1→h2→h3, no skipping) per page.
+- **Images:** meaningful images get descriptive `alt`; decorative ones get `alt=""`
+  + `aria-hidden`.
+- **Forms:** see §9.
+- **Reduced motion** respected (§7).
+- **Color never the sole indicator** (§6).
+
+---
+
+## 9. Forms & feedback
+
+- **Visible label per field** (not placeholder-only). Mark required fields.
+- **Errors below the related field**, stated as cause + fix (not "Invalid"). Use
+  `role="alert"` / `aria-live="polite"` so screen readers announce them; focus the first
+  invalid field on submit.
+- **Validate on blur**, not per keystroke.
+- **Submit feedback:** disable the button + show progress during async; confirm success.
+- **Semantic input types** (`email`, `tel`, `number`) for correct mobile keyboards;
+  password fields get a show/hide toggle; enable autofill (`autocomplete`).
+- **Disabled state:** reduced opacity (~0.38–0.5) + non-interactive; distinct from read-only.
+- **Confirm destructive actions** (use `confirmDialog`, which exists) and prefer undo where feasible.
+
+---
+
+## 10. Navigation
+
+- **Active location highlighted** (color/weight/indicator) — NavBar uses `isActive`.
+- **Adaptive:** sidebar/drawer on small screens, inline bar on desktop (NavBar already
+  switches at `md`). Don't mix tab + sidebar + bottom nav at the same level.
+- **Deep-linkable:** key screens reachable by URL (e.g. `/leaderboard?variant=jp&type=RANKED`).
+- **Back is predictable;** preserve scroll/filter state where possible.
+- **Destructive items** (logout, delete) visually separated from normal nav.
+
+---
+
+## 11. Data grids & charts
+
+- **DataGrid** styling is themed (`MuiDataGrid` override + `responsiveDataGridContainer`).
+  Use `density="compact"` and `disableColumnMenu` on mobile (`useMediaQuery`), and the
+  `100dvh`-based height so the grid fits the visible viewport.
+- **Tabular numerals** in numeric columns; right-align numbers.
+- **Charts:** match type to data (trend→line, comparison→bar, proportion→pie ≤5 slices);
+  always show a legend + tooltips; **don't rely on color alone** (add labels/patterns —
+  `placement` colors are paired with rank numbers); provide loading & empty states;
+  reflow/simplify on small screens; respect reduced-motion for entrance animation.
+
+---
+
+## 12. Performance
+
+- **Optimize images:** prefer **WebP/AVIF**, provide responsive sizes, and **lazy-load
+  below-the-fold** media (`loading="lazy"`).
+  ✅ The hero is now `public/hero.webp` (~113 KB, was a 6.5 MB PNG). Keep new raster
+  assets in WebP/AVIF; convert with `npx sharp-cli --input x.png --output x.webp --format webp -q 82`.
+- **Reserve space** for async/media content (declare dimensions / `aspectRatio`) to keep
+  **CLS < 0.1**.
+- **Code-split routes** — keep using `React.lazy` per route (see `App.tsx`).
+- **Virtualize** lists of 50+ rows (DataGrid handles this).
+- Batch DOM reads/writes; debounce/throttle scroll/resize/input handlers.
+
+---
+
+## 13. Recorded gotchas (lessons from this codebase)
+
+- **Gradient/scrim breakpoint flip:** a scrim that was horizontal (dark-left) at `md`
+  but vertical at `xs` made the dark area "jump" when narrowing. Keep one anchor across
+  breakpoints (§6).
+- **Sticky touch hover:** transforms on `:hover` without `@media (hover: hover)` stick
+  after a tap on touch devices (§7).
+- **`100vh` mobile overflow:** use `100dvh` (§4).
+- **iOS input zoom:** inputs < 16px auto-zoom on focus (§5).
+- **HK cascade asymmetry** (backend) — unrelated to UI but noted in CLAUDE.md.
+
+---
+
+## 14. Pre-commit UI checklist
+
+- [ ] Renders with no horizontal scroll at 375px, and at sm/md/lg.
+- [ ] Spacing uses the 8px scale; touch targets ≥44px and ≥8px apart.
+- [ ] No hardcoded colors — tokens / theme palette only.
+- [ ] Text contrast ≥4.5:1 (≥3:1 large/secondary); color never the only signal.
+- [ ] Focus visible; icon-only buttons have `aria-label`; keyboard operable.
+- [ ] Hover effects guarded by `@media (hover: hover)`; motion ≤300ms and respects
+      `prefers-reduced-motion`.
+- [ ] Images have `alt`, declared dimensions, and are lazy-loaded below the fold.
+- [ ] Responsive gradients keep a consistent anchor across breakpoints.
+- [ ] `npx tsc --noEmit` and `npx eslint` pass for changed files.
+
+---
+
+## 15. Theme & token reference (current — single source of truth)
+
+> Source: `frontend/src/theme/tokens.ts`, `frontend/src/theme/index.ts`,
+> `frontend/src/theme/utils.ts`. Keep this section in sync if the theme changes.
+
+### Palette mode: **dark only** (`createTheme(..., { palette: { mode: "dark" } })`)
+
+**Surfaces** (`tokens.surface`)
+| token | value |
+|-------|-------|
+| `background` | `#0B0B0C` |
+| `paper` | `#161617` |
+
+**Primary / accent** (`tokens.palette.primary`) — pastel red; `info` reuses these
+| token | value |
+|-------|-------|
+| `primary.main` | `#E78B8B` |
+| `primary.light` | `#F2B0B0` |
+| `primary.dark` | `#C56A6A` |
+| `primary.contrastText` | `#0B0B0C` |
+
+**Medals** (`tokens.palette.medal`) — text + translucent bg
+| place | text | bg |
+|-------|------|----|
+| gold | `#E6C65C` | `rgba(212,175,55,0.14)` |
+| silver | `#C7C7C7` | `rgba(199,199,199,0.12)` |
+| bronze | `#C58A4B` | `rgba(197,138,75,0.14)` |
+
+**Placement colors** (`tokens.placement`, used by charts/stats)
+`1 → gold`, `2 → silver`, `3 → bronze`, `4 → #8C8C92` (neutral gray).
+
+**Icon tokens** (`tokens.palette.icon`)
+`badgeLight #F2B0B0`, `badgeDark rgba(231,139,139,0.15)`, `surfaceLight rgba(255,255,255,0.06)`.
+
+**Overlays** (`tokens.overlay`)
+| group | token | value |
+|-------|-------|-------|
+| white | `subtle / medium / strong` | `rgba(255,255,255, 0.15 / 0.18 / 0.3)` |
+| dark | `header` | `rgba(255,255,255,0.03)` |
+| dark | `hover` | `rgba(255,255,255,0.06)` |
+| dark | `border` (= `divider`) | `rgba(255,255,255,0.12)` |
+| dark | `shadow` | `rgba(0,0,0,0.5)` |
+| dark | `overlay` (scrim) | `rgba(0,0,0,0.6)` |
+| primary | `row` | `rgba(231,139,139,0.08)` |
+| primary | `focus` | `rgba(231,139,139,0.20)` |
+| primary | `glow` | `rgba(231,139,139,0.25)` |
+| primary | `card` | `rgba(231,139,139,0.18)` |
+
+**Shadows** (`tokens.shadow`)
+`nav`, `card`, `button`, `dialog`, `sm`, `md` — built from the overlay tokens above.
+(`elevation1 → sm`, `elevation3 → md`; Paper `backgroundImage: none`.)
+
+**Gradients** (`tokens.gradient`)
+| token | value |
+|-------|-------|
+| `primary` | `linear-gradient(90deg, #E78B8B, #F2B0B0)` |
+| `title` | `linear-gradient(90deg, #FFFFFF, #F2B0B0)` (hero/gradient-title look) |
+
+**Motion** (`tokens.timing`)
+`fast 0.12s`, `normal 0.18s`, `slow 0.22s`, `ease cubic-bezier(0.4,0,0.2,1)`.
+
+### Typography (`theme.typography`)
+- `fontFamily`: `"Manrope", "system-ui", -apple-system, sans-serif`.
+- Fluid headings (`clamp`): `h1 1.6→2.2rem / 800`, `h2 1.25→1.6rem / 700`,
+  `h3 1→1.25rem / 700`. Static: `h4 1.1rem`, `h5 1rem`, `h6 0.95rem` (600–700).
+- `body1 0.9rem / 1.6`, `body2 0.825rem / 1.5`, `caption 0.75rem`.
+- `button`: `textTransform: none`, weight 500.
+- ⚠️ Body is < 16px — see §5 note about mobile inputs.
+
+### Shape & spacing
+- `shape.borderRadius: 10`; component radii: Button 8, Card/Alert 12, Dialog 16,
+  Menu/Autocomplete 10, Chip 20, Drawer paper `0 16px 16px 0`.
+- `spacing: 8` (8px base unit).
+
+### Key component overrides (`theme.components`)
+- **Button:** min-height 44 (sm 40, lg 46), no elevation, lift on hover only via
+  `@media (hover: hover)`, contained gets `shadow.button` on hover.
+- **IconButton:** min 44×44, scale 1.08 on hover (hover devices only).
+- **Card:** 12px radius, 1px divider border, border→`primary.light` on hover.
+- **TextField/Autocomplete:** `size="small"` default, 8–10px radius, focus ring
+  `0 0 0 3px overlay.primary.focus`, hover border `primary.light`.
+- **Container:** responsive padding (16px, 24px ≥md; 24px top/bottom).
+- **AppBar/Menu:** flat, 1px `overlay.dark.border`, `shadow.nav` on menus.
+- **DataGrid:** 12px radius, header bg `overlay.dark.header`, row hover
+  `overlay.primary.row` + pointer, no cell focus outline.
+- **Alert:** outlined default, 12px radius, blurred paper bg, per-severity border colors.
+- **ListItemButton:** 8px radius, indents 4px on hover.
+
+### Reusable `sx` presets (`@/theme/utils`)
+| export | use for |
+|--------|---------|
+| `responsiveDataGridContainer` | DataGrid wrapper sizing (`100dvh`-aware height, minHeight 400) |
+| `gradientTitle` | white→accent gradient heading (fluid 2→3.15rem) |
+| `responsiveCardHover` | card hover lift + accent top-bar (disabled on `xs`) |
+| `responsiveTextTruncate` | ellipsis with responsive max-width |
+| `navButton` | compact nav button styling |
+| `SpacedToggleButtonGroup` | `styled` ToggleButtonGroup with gap + rounded segments |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,15 @@
             name="description"
             content="UBC Mahjong Club Website"
     />
+    <!-- Manrope: the theme's typography.fontFamily. preconnect + display=swap
+         avoids a blocking request / FOIT on cellular; the variable range covers
+         every weight the UI uses (400–800, incl. the 750 in the score footer). -->
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+    <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Manrope:wght@400..800&display=swap"
+    />
     <link rel="apple-touch-icon" href="logo192.png"/>
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,8 @@ import WithNav from "@/common/WithNav";
 import { AuthContextProvider } from "@/common/AuthContext";
 import ErrorBoundary from "@/common/ErrorBoundary";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { CssBaseline, ThemeProvider } from "@mui/material";
-import { createAppTheme } from "@/theme";
+import { CssBaseline } from "@mui/material";
+import { AccentProvider } from "@/theme/AccentContext";
 import { GameNotFound } from "@/game/common/GameNotFound";
 import React from "react";
 import Tournament from "./resources/Tournament";
@@ -51,11 +51,10 @@ const useQuery = () => {
 
 const App = () => {
     const query = useQuery();
-    const theme = createAppTheme();
 
     return (
         <ErrorBoundary>
-            <ThemeProvider theme={theme}>
+            <AccentProvider>
                 <QueryClientProvider client={queryClient}>
                     <AuthContextProvider>
                         <CssBaseline />
@@ -157,7 +156,7 @@ const App = () => {
                         </main>
                     </AuthContextProvider>
                 </QueryClientProvider>
-            </ThemeProvider>
+            </AccentProvider>
         </ErrorBoundary>
     );
 };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,10 +2,14 @@ import ReactDOM from "react-dom/client";
 import App from "@/App";
 import { BrowserRouter } from "react-router-dom";
 import React from "react";
+import InitColorSchemeScript from "@mui/material/InitColorSchemeScript";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
     <React.StrictMode>
+        {/* Sets the resolved color scheme (incl. the OS-resolved one for "system")
+            on <html> before the app paints, so there's no flash of the wrong theme. */}
+        <InitColorSchemeScript defaultMode="system" attribute="data-mui-color-scheme" />
         <BrowserRouter>
             <App />
         </BrowserRouter>

--- a/frontend/src/theme/AccentContext.tsx
+++ b/frontend/src/theme/AccentContext.tsx
@@ -1,0 +1,74 @@
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useMemo,
+    useState,
+    type ReactNode,
+} from "react";
+import { ThemeProvider } from "@mui/material/styles";
+import { createAppTheme } from "@/theme";
+import type { AccentKey } from "@/theme/tokens";
+
+const STORAGE_KEY = "mjc-accent";
+const DEFAULT_ACCENT: AccentKey = "red";
+
+const isAccentKey = (value: string | null): value is AccentKey =>
+    value === "red" || value === "blue" || value === "green";
+
+const readStoredAccent = (): AccentKey => {
+    if (typeof window === "undefined") {
+        return DEFAULT_ACCENT;
+    }
+    try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        return isAccentKey(stored) ? stored : DEFAULT_ACCENT;
+    } catch {
+        return DEFAULT_ACCENT;
+    }
+};
+
+interface AccentContextValue {
+    accent: AccentKey;
+    setAccent: (accent: AccentKey) => void;
+}
+
+const AccentContext = createContext<AccentContextValue>({
+    accent: DEFAULT_ACCENT,
+    setAccent: () => {
+        /* overridden by AccentProvider */
+    },
+});
+
+/** Read/set the active accent. Orthogonal to MUI's `useColorScheme` (mode). */
+export const useAccent = (): AccentContextValue => useContext(AccentContext);
+
+/**
+ * Persists the accent choice in localStorage (default "red") and rebuilds the
+ * MUI theme via ThemeProvider when it changes. Accent and color scheme are
+ * independent: switching accent rebuilds the theme but preserves both schemes,
+ * so MUI's `useColorScheme` mode handling is untouched.
+ */
+export const AccentProvider = ({ children }: { children: ReactNode }) => {
+    const [accent, setAccentState] = useState<AccentKey>(readStoredAccent);
+
+    const setAccent = useCallback((next: AccentKey) => {
+        setAccentState(next);
+        try {
+            window.localStorage.setItem(STORAGE_KEY, next);
+        } catch {
+            /* ignore persistence failures (private mode, storage disabled, etc.) */
+        }
+    }, []);
+
+    const theme = useMemo(() => createAppTheme(accent), [accent]);
+    const value = useMemo<AccentContextValue>(() => ({ accent, setAccent }), [accent, setAccent]);
+
+    return (
+        <AccentContext.Provider value={value}>
+            <ThemeProvider theme={theme} defaultMode="system">
+                {children}
+            </ThemeProvider>
+        </AccentContext.Provider>
+    );
+};

--- a/frontend/src/theme/animations.ts
+++ b/frontend/src/theme/animations.ts
@@ -1,0 +1,10 @@
+import { keyframes } from "@mui/system";
+
+// Gentle "breathing" pulse for live-indicator dots (nav Record button, live
+// game header, live game cards). Shared so every live indicator animates
+// identically.
+export const pulse = keyframes`
+    0%   { opacity: 1;    transform: scale(1);   }
+    50%  { opacity: 0.35; transform: scale(0.8); }
+    100% { opacity: 1;    transform: scale(1);   }
+`;

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,108 +1,329 @@
-import { createTheme, Theme, ThemeOptions } from "@mui/material/styles";
+import { createTheme, Theme, ThemeOptions, PaletteOptions } from "@mui/material/styles";
 import { enUS } from "@mui/x-date-pickers/locales";
+import {
+    AccentKey,
+    AccentTokens,
+    buildAccentTokens,
+    buildSchemeTokens,
+    SchemeTokens,
+    timing,
+} from "@/theme/tokens";
 
-const colors = {
-    light: "#FAFAFA",
-} as const;
+/**
+ * Accent tint tokens exposed as CSS variables so components that aren't covered
+ * by the MUI `primary` palette (faint badge/row tints) still follow a runtime
+ * accent switch via `var(--mui-palette-accentTint-*)`.
+ */
+interface AccentTint {
+    row: string;
+    focus: string;
+    glow: string;
+    card: string;
+    badgeLight: string;
+    badgeDark: string;
+}
 
-export const createAppTheme = (): Theme => {
+/**
+ * Custom, scheme-aware palette tokens. Registering them under each scheme's
+ * `palette` lets MUI emit `--mui-palette-*` CSS variables that flip between
+ * light and dark automatically. Components read them via `theme.vars.palette.*`
+ * (callbacks/styled) or `var(--mui-palette-*)` (static sx objects).
+ */
+declare module "@mui/material/styles" {
+    interface Palette {
+        glass: SchemeTokens["glass"];
+        gradient: SchemeTokens["gradient"] & { primary: string };
+        overlayN: SchemeTokens["overlay"];
+        appShadow: SchemeTokens["shadow"];
+        accentTint: AccentTint;
+    }
+    interface PaletteOptions {
+        glass?: SchemeTokens["glass"];
+        gradient?: SchemeTokens["gradient"] & { primary: string };
+        overlayN?: SchemeTokens["overlay"];
+        appShadow?: SchemeTokens["shadow"];
+        accentTint?: AccentTint;
+    }
+}
+
+const schemePalette = (
+    scheme: "light" | "dark",
+    schemes: { light: SchemeTokens; dark: SchemeTokens },
+    accentTokens: AccentTokens,
+): PaletteOptions => {
+    const s = schemes[scheme];
+    return {
+        mode: scheme,
+        // Accent is toned per scheme (pastel in dark, deeper ramp in light)
+        // so it stays readable on each background; see schemeTokens[*].accent.
+        primary: { ...s.accent },
+        // Info reuses the accent so info alerts/icons match the theme.
+        info: { ...s.accent },
+        background: {
+            default: s.surface.background,
+            paper:   s.surface.paper,
+        },
+        divider: s.overlay.border,
+        glass: s.glass,
+        gradient: { primary: accentTokens.gradientAccent.primary, ...s.gradient },
+        overlayN: s.overlay,
+        appShadow: s.shadow,
+        accentTint: {
+            ...accentTokens.overlayAccent,
+            badgeLight: accentTokens.icon.badgeLight,
+            badgeDark:  accentTokens.icon.badgeDark,
+        },
+    };
+};
+
+export const createAppTheme = (accent: AccentKey): Theme => {
+    const schemes = buildSchemeTokens(accent);
+    const accentTokens = buildAccentTokens(accent);
+    const { overlayAccent } = accentTokens;
     const baseThemeOptions: ThemeOptions = {
-        palette: {
-            background: {
-                default: colors.light,
-                paper: "#ffffff",
-            },
+        // CSS variables let both schemes coexist; the manual toggle flips the
+        // `data-mui-color-scheme` attribute on <html> with no re-render flash.
+        cssVariables: { colorSchemeSelector: "data" },
+        colorSchemes: {
+            light: { palette: schemePalette("light", schemes, accentTokens) },
+            dark:  { palette: schemePalette("dark", schemes, accentTokens) },
         },
         typography: {
-            h1: {
-                fontSize: "clamp(2rem, 5vw, 3rem)",
-            },
-            h2: {
-                fontSize: "clamp(1.5rem, 3.5vw, 2.125rem)",
-            },
-            h3: {
-                fontSize: "clamp(1.25rem, 3vw, 1.75rem)",
-            },
-            h4: {
-                fontSize: "1.5rem",
-            },
-            h5: {
-                fontSize: "1.25rem",
-            },
-            h6: {
-                fontSize: "1.1rem",
-            },
-
-            button: {
-                textTransform: "none", // More modern, readable buttons
-            },
+            fontFamily: '"Manrope", "system-ui", -apple-system, sans-serif',
+            h1: { fontSize: "clamp(1.6rem, 4vw, 2.2rem)",   fontWeight: 800, letterSpacing: "-0.02em"  },
+            h2: { fontSize: "clamp(1.25rem, 3vw, 1.6rem)",  fontWeight: 700, letterSpacing: "-0.015em" },
+            h3: { fontSize: "clamp(1rem, 2.5vw, 1.25rem)",  fontWeight: 700, letterSpacing: "-0.01em"  },
+            h4: { fontSize: "1.1rem",  fontWeight: 700 },
+            h5: { fontSize: "1rem",    fontWeight: 700 },
+            h6: { fontSize: "0.95rem", fontWeight: 600 },
+            body1:   { fontSize: "0.9rem",   lineHeight: 1.6 },
+            body2:   { fontSize: "0.825rem", lineHeight: 1.5 },
+            caption: { fontSize: "0.75rem" },
+            button:  { textTransform: "none", fontWeight: 500 },
         },
+        shape: { borderRadius: 10 },
         components: {
-            // Touch-friendly buttons (minimum 44px height for iOS/Android)
             MuiButton: {
-                defaultProps: {
-                    disableElevation: true,
-                    sx: {
-                        minHeight: 44,
-                        padding: "10px 20px",
-                        minWidth: {
-                            xs: "100%",
-                            sm: "200px",
-                        },
-                    },
-                },
+                defaultProps: { disableElevation: true },
                 styleOverrides: {
-                    sizeLarge: {
-                        minHeight: 48,
-                        padding: "12px 24px",
+                    root: {
+                        minHeight: 44,
+                        padding: "8px 18px",
+                        borderRadius: 8,
+                        fontWeight: 500,
+                        transition: `all ${timing.normal} ${timing.ease}`,
+                        // Only lift on real hover devices; on touch a :hover transform
+                        // latches after a tap until the next interaction.
+                        "@media (hover: hover)": {
+                            "&:hover": { transform: "translateY(-1px)" },
+                        },
+                        "&:active": { transform: "translateY(0)" },
                     },
-                    sizeSmall: {
-                        minHeight: 36,
-                        padding: "6px 12px",
-                    },
+                    contained: ({ theme }) => ({
+                        boxShadow: "none",
+                        "&:hover": { boxShadow: theme.vars.palette.appShadow.button },
+                    }),
+                    sizeSmall: { minHeight: 40, padding: "5px 12px", fontSize: "0.8rem" },
+                    sizeLarge: { minHeight: 46, padding: "12px 24px" },
                 },
             },
-            // Consistent card styling with hover effects
             MuiCard: {
                 styleOverrides: {
                     root: ({ theme }) => ({
                         borderRadius: 12,
                         border: "1px solid",
-                        borderColor: theme.palette.divider,
-                        transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+                        borderColor: theme.vars.palette.divider,
+                        boxShadow: "none",
+                        transition: `border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease`,
+                        "&:hover": { borderColor: theme.vars.palette.primary.light },
                     }),
                 },
             },
-            // Container with responsive vertical/horizontal spacing
-            MuiContainer: {
+            MuiCardActionArea: {
+                styleOverrides: {
+                    root: {
+                        borderRadius: 12,
+                        "&:hover .MuiCardActionArea-focusHighlight": { opacity: 0.04 },
+                    },
+                },
+            },
+            MuiPaper: {
+                styleOverrides: {
+                    root:       { backgroundImage: "none" },
+                    elevation1: ({ theme }) => ({ boxShadow: theme.vars.palette.appShadow.sm }),
+                    elevation3: ({ theme }) => ({ boxShadow: theme.vars.palette.appShadow.md }),
+                },
+            },
+            MuiTextField: {
+                defaultProps: { size: "small" },
                 styleOverrides: {
                     root: ({ theme }) => ({
-                        paddingLeft: theme.spacing(2),
-                        paddingRight: theme.spacing(2),
-                        paddingTop: theme.spacing(2),
-                        paddingBottom: theme.spacing(2),
-                        [theme.breakpoints.up("md")]: {
-                            paddingLeft: theme.spacing(3),
-                            paddingRight: theme.spacing(3),
-                            paddingTop: theme.spacing(3),
-                            paddingBottom: theme.spacing(3),
+                        "& .MuiOutlinedInput-root": {
+                            borderRadius: 8,
+                            transition: `box-shadow ${timing.fast} ease`,
+                            "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: theme.vars.palette.primary.light },
+                            "&.Mui-focused": { boxShadow: `0 0 0 3px ${overlayAccent.focus}` },
+                        },
+                        // iOS auto-zooms when a focused input's font is < 16px. Keep
+                        // the compact 0.9rem on ≥sm, but bump to 16px on phones.
+                        "& .MuiInputBase-input": {
+                            [theme.breakpoints.down("sm")]: { fontSize: 16 },
                         },
                     }),
                 },
             },
-
-            // IconButton touch targets
-            MuiIconButton: {
+            MuiAutocomplete: {
+                defaultProps: { size: "small" },
+                styleOverrides: {
+                    paper:  ({ theme }) => ({ borderRadius: 10, boxShadow: theme.vars.palette.appShadow.nav }),
+                    option: { borderRadius: 6, margin: "2px 6px", padding: "6px 8px", fontSize: "0.875rem" },
+                },
+            },
+            MuiChip: {
+                styleOverrides: {
+                    root:      { borderRadius: 20, fontWeight: 500, fontSize: "0.75rem" },
+                    sizeSmall: { height: 22, fontSize: "0.7rem" },
+                },
+            },
+            MuiContainer: {
+                styleOverrides: {
+                    root: ({ theme }) => ({
+                        paddingLeft:  theme.spacing(2),
+                        paddingRight: theme.spacing(2),
+                        paddingTop:    theme.spacing(3),
+                        paddingBottom: theme.spacing(3),
+                        [theme.breakpoints.up("md")]: {
+                            paddingLeft:  theme.spacing(3),
+                            paddingRight: theme.spacing(3),
+                        },
+                    }),
+                },
+            },
+            MuiAppBar: {
+                styleOverrides: {
+                    root: ({ theme }) => ({
+                        boxShadow: "none",
+                        borderBottom: `1px solid ${theme.vars.palette.divider}`,
+                    }),
+                },
+            },
+            MuiMenu: {
+                styleOverrides: {
+                    paper: ({ theme }) => ({
+                        borderRadius: 10,
+                        boxShadow: theme.vars.palette.appShadow.nav,
+                        border: `1px solid ${theme.vars.palette.divider}`,
+                    }),
+                },
+            },
+            MuiMenuItem: {
                 styleOverrides: {
                     root: {
-                        padding: 12, // Ensures 44px touch target with 20px icon
+                        borderRadius: 6,
+                        margin: "2px 6px",
+                        padding: "7px 10px",
+                        fontSize: "0.875rem",
+                        minWidth: 160,
+                        transition: `background ${timing.fast}`,
                     },
                 },
             },
+            MuiAlert: {
+                defaultProps: { variant: "outlined" },
+                styleOverrides: {
+                    root: ({ theme }) => ({
+                        borderRadius: 12,
+                        padding: "10px 16px",
+                        fontSize: "0.9rem",
+                        alignItems: "center",
+                        backgroundColor: theme.vars.palette.background.paper,
+                        backdropFilter: "blur(8px)",
+                        border: "1px solid",
+                        borderColor: theme.vars.palette.divider,
+                    }),
+                    icon: { opacity: 0.9 },
+                    message: { paddingTop: 0, paddingBottom: 0, fontWeight: 500 },
+                    standardError:   { borderColor: "rgba(244,67,54,0.4)" },
+                    standardSuccess: { borderColor: "rgba(102,187,106,0.4)" },
+                    standardWarning: { borderColor: "rgba(255,167,38,0.4)" },
+                    standardInfo:    { borderColor: overlayAccent.focus },
+                    outlinedInfo:    ({ theme }) => ({ borderColor: overlayAccent.focus, color: theme.vars.palette.primary.light }),
+                },
+            },
+            MuiDialog: {
+                styleOverrides: {
+                    paper: ({ theme }) => ({ borderRadius: 16, boxShadow: theme.vars.palette.appShadow.dialog }),
+                },
+            },
+            MuiTooltip: {
+                styleOverrides: {
+                    tooltip: { borderRadius: 6, fontSize: "0.75rem" },
+                },
+            },
+            MuiDataGrid: {
+                styleOverrides: {
+                    root: ({ theme }) => ({
+                        borderRadius: 12,
+                        border: `1px solid ${theme.vars.palette.divider}`,
+                        "& .MuiDataGrid-columnHeader": {
+                            backgroundColor: theme.vars.palette.overlayN.header,
+                            fontWeight: 600,
+                        },
+                        "& .MuiDataGrid-row": { transition: `background ${timing.fast}` },
+                        "& .MuiDataGrid-row:hover": {
+                            backgroundColor: overlayAccent.row,
+                            cursor: "pointer",
+                        },
+                        "& .MuiDataGrid-cell:focus, & .MuiDataGrid-cell:focus-within": {
+                            outline: "none",
+                        },
+                    }),
+                },
+            },
+            MuiIconButton: {
+                styleOverrides: {
+                    root: {
+                        // 44px minimum keeps icon buttons within reach as touch targets.
+                        minWidth: 44,
+                        minHeight: 44,
+                        borderRadius: 8,
+                        transition: `background ${timing.fast}, transform ${timing.fast}`,
+                        "@media (hover: hover)": {
+                            "&:hover": { transform: "scale(1.08)" },
+                        },
+                    },
+                },
+            },
+            MuiPagination: {
+                styleOverrides: {
+                    root: {
+                        "& .MuiPaginationItem-root": {
+                            borderRadius: 8,
+                            fontWeight: 500,
+                            transition: `all ${timing.fast}`,
+                        },
+                        "& .MuiPaginationItem-root:hover": { transform: "translateY(-1px)" },
+                    },
+                },
+            },
+            MuiListItemButton: {
+                styleOverrides: {
+                    root: {
+                        borderRadius: 8,
+                        margin: "1px 6px",
+                        transition: `background ${timing.fast}, padding-left 0.15s`,
+                        "&:hover": { paddingLeft: "20px" },
+                    },
+                },
+            },
+            MuiDrawer: {
+                styleOverrides: {
+                    paper: { borderRadius: "0 16px 16px 0" },
+                },
+            },
         },
-        // Responsive spacing scale (8px base unit)
         spacing: 8,
     };
 
-    return createTheme({ ...baseThemeOptions, colorSchemes: { dark: true } }, enUS);
+    return createTheme(baseThemeOptions, enUS);
 };

--- a/frontend/src/theme/tokens.ts
+++ b/frontend/src/theme/tokens.ts
@@ -1,0 +1,319 @@
+/**
+ * Design tokens — single source of truth for all raw values.
+ * Never reference these hex/rgba strings directly in component files;
+ * import a token instead so changes propagate everywhere automatically.
+ *
+ * ACCENT VARIANTS — the brand accent is a *named variant* (`red` | `blue` | `green`),
+ * not a frozen constant. Every accent-derived value (the primary ramp, icon
+ * badges, overlay tints, accent gradient, and both per-scheme accent ramps +
+ * gradient titles) is produced from an `AccentDefinition` via `buildAccentTokens`
+ * / `buildSchemeTokens`. The default is `red`, whose values are pixel-identical
+ * to the historical hardcoded ones. The active accent is chosen at runtime (see
+ * theme/AccentContext) and rebuilds the MUI theme; components that must follow
+ * the switch read the accent through `theme.vars.palette.*` /
+ * `var(--mui-palette-*)` rather than importing the static red bundle below.
+ *
+ * Scheme-aware neutrals (surfaces / overlays / glass / gradients / shadows)
+ * live in `buildSchemeTokens` further down and flip per color scheme via CSS
+ * variables. Accent and color scheme are orthogonal.
+ */
+
+export type AccentKey = "red" | "blue" | "green";
+
+interface AccentDefinition {
+    /**
+     * Frozen pastel ramp — used verbatim as the dark-scheme accent, and as the
+     * source for icon badges, overlay tints, and the accent gradient.
+     */
+    pastel: { main: string; light: string; dark: string };
+    /** RGB channels of `pastel.main`, for building translucent accent tints. */
+    mainRgb: string;
+    /**
+     * Deeper, contrast-safe ramp for the light scheme — clears ~4.5:1 on white
+     * where the pastel ramp is too light to read.
+     */
+    light: { main: string; light: string; dark: string };
+    /** Start color of the light-scheme gradient title (paired with `pastel.light`). */
+    lightTitleStart: string;
+}
+
+/**
+ * The three accent variants. `blue` and `green` are `red` hue-rotated (to a
+ * true azure / green) with lightness/saturation held constant, so each reads as
+ * the same pastel/depth in its own hue. Blues and greens are perceptually darker
+ * than reds at equal HSL lightness, so their light-scheme ramps clear 4.5:1 on
+ * white with margin.
+ */
+export const accents: Record<AccentKey, AccentDefinition> = {
+    red: {
+        pastel: { main: "#E78B8B", light: "#F2B0B0", dark: "#C56A6A" },
+        mainRgb: "231,139,139",
+        light: { main: "#AE424A", light: "#C1585F", dark: "#8A2F37" },
+        lightTitleStart: "#cf5252",
+    },
+    blue: {
+        pastel: { main: "#8BA9E7", light: "#B0C6F2", dark: "#6A88C5" },
+        mainRgb: "139,169,231",
+        light: { main: "#4266AE", light: "#587BC1", dark: "#2F4D8A" },
+        lightTitleStart: "#527CCF",
+    },
+    green: {
+        pastel: { main: "#8BE7B6", light: "#B0F2CF", dark: "#6AC594" },
+        mainRgb: "139,231,182",
+        light: { main: "#1D7546", light: "#228A53", dark: "#165A36" },
+        lightTitleStart: "#238D54",
+    },
+};
+
+/** Accent-derived token bundle (primary ramp, icon badges, overlays, gradient). */
+export interface AccentTokens {
+    primary: { main: string; light: string; dark: string };
+    icon: { badgeLight: string; badgeDark: string };
+    overlayAccent: { row: string; focus: string; glow: string; card: string };
+    gradientAccent: { primary: string };
+}
+
+export const buildAccentTokens = (key: AccentKey): AccentTokens => {
+    const a = accents[key];
+    return {
+        // Pastel accent ramp (frozen per variant).
+        primary: { ...a.pastel },
+        icon: {
+            // Light pastel — used for the animated accent bar / nav underline.
+            badgeLight: a.pastel.light,
+            badgeDark: `rgba(${a.mainRgb},0.15)`,
+        },
+        // Pastel-tinted accent overlays — translucent so they read on either a
+        // dark or a light surface (intentionally scheme-independent).
+        overlayAccent: {
+            row: `rgba(${a.mainRgb},0.08)`,
+            focus: `rgba(${a.mainRgb},0.20)`,
+            glow: `rgba(${a.mainRgb},0.25)`,
+            card: `rgba(${a.mainRgb},0.18)`,
+        },
+        // Accent gradient (white-free) — same in both schemes.
+        gradientAccent: {
+            primary: `linear-gradient(90deg, ${a.pastel.main}, ${a.pastel.light})`,
+        },
+    };
+};
+
+/** Frozen finishing-position medal colors — never accent-dependent. */
+const medal = {
+    gold: { text: "#E6C65C", bg: "rgba(212,175,55,0.14)" },
+    silver: { text: "#C7C7C7", bg: "rgba(199,199,199,0.12)" },
+    bronze: { text: "#C58A4B", bg: "rgba(197,138,75,0.14)" },
+} as const;
+
+/** Default (red) accent bundle. */
+const redTokens = buildAccentTokens("red");
+
+/**
+ * Static default (red) accent exports, kept for components that read these at
+ * import time AND don't need to follow a runtime accent switch (e.g. the medal
+ * palette). Anything that should follow the switch reads the accent through the
+ * theme (`theme.vars.palette.*` / `var(--mui-palette-*)`) instead.
+ */
+export const palette = {
+    primary: redTokens.primary,
+    medal,
+    icon: redTokens.icon,
+} as const;
+
+export const overlayAccent = redTokens.overlayAccent;
+export const gradientAccent = redTokens.gradientAccent;
+
+/** Dark ink for text/icons sitting on bright accent fills (gradient chips, placement bars). */
+export const onAccent = {
+    strong: "rgba(0,0,0,0.85)",
+    muted: "rgba(0,0,0,0.75)",
+} as const;
+
+/**
+ * Finishing-position colors (1st–4th). Single source of truth shared by the
+ * placement history chart, the placement stat cards, and the distribution bar.
+ * 1st–3rd reuse the (frozen) medal palette; 4th is a dark grayish copper that
+ * stays legible on both light and dark surfaces.
+ */
+export const placement = {
+    1: palette.medal.gold.text,
+    2: palette.medal.silver.text,
+    3: palette.medal.bronze.text,
+    4: "#563a33",
+} as const;
+
+export const timing = {
+    fast: "0.12s",
+    normal: "0.18s",
+    slow: "0.22s",
+    ease: "cubic-bezier(0.4,0,0.2,1)",
+} as const;
+
+/** Shape of one scheme's neutral token set. */
+export interface SchemeTokens {
+    /**
+     * Scheme-appropriate rendering of the brand accent for the MUI `primary`
+     * (and `info`) palette. Dark mode uses the variant's pastel ramp verbatim;
+     * light mode uses a deeper ramp so accent text/buttons stay readable on
+     * white. This only governs how the accent is *toned per scheme* for contrast.
+     */
+    accent: { main: string; light: string; dark: string; contrastText: string };
+    surface: { background: string; paper: string };
+    /** Neutral on-surface separators/overlays (scheme-appropriate contrast). */
+    overlay: {
+        header: string;
+        hover: string;
+        border: string;
+        shadow: string;
+        overlay: string;
+    };
+    /**
+     * Translucent "glass" system for the sticky AppBar and its controls
+     * (blurred bar + frosted buttons). Dark mode layers light-on-dark; light
+     * mode layers dark-on-light so the same elements stay visible.
+     */
+    glass: {
+        bar: string;
+        border: string;
+        borderHover: string;
+        fillSubtle: string;
+        fill: string;
+        cta: string;
+        iconHover: string;
+        fillStrong: string;
+        skeleton: string;
+    };
+    /** White/near-black-built gradients, adapted per scheme (accent stays per-variant). */
+    gradient: {
+        title: string;
+        hero: string;
+        heroScrim: string;
+        /** Bottom-fixed game Footer: transparent → solid surface (top→bottom). */
+        footerFade: string;
+    };
+    shadow: {
+        nav: string;
+        card: string;
+        button: string;
+        dialog: string;
+        sm: string;
+        md: string;
+    };
+}
+
+const darkOverlay: SchemeTokens["overlay"] = {
+    // Separators/surfaces on the dark theme are light-on-dark so they stay visible.
+    header: "rgba(255,255,255,0.05)",
+    hover: "rgba(255,255,255,0.06)",
+    border: "rgba(255,255,255,0.12)",
+    shadow: "rgba(0,0,0,0.5)",
+    overlay: "rgba(0,0,0,0.6)",
+};
+
+const lightOverlay: SchemeTokens["overlay"] = {
+    // Light-on-light counterparts: dark-tinted so separators/hover/shadows
+    // stay clearly visible against a near-white surface. Kept deliberately
+    // stronger than a naive 0.05/0.12 set, which washes out on white.
+    header: "rgba(0,0,0,0.05)",
+    hover: "rgba(0,0,0,0.08)",
+    border: "rgba(0,0,0,0.22)",
+    shadow: "rgba(0,0,0,0.22)",
+    overlay: "rgba(0,0,0,0.5)",
+};
+
+/**
+ * Build the per-scheme neutral token sets for a given accent. Only the
+ * accent-derived values (per-scheme `accent` ramp, `gradient.title`, and the
+ * accent-tinted card/button shadows) depend on the accent; every neutral
+ * surface/overlay/glass/hero token is identical across variants.
+ */
+export const buildSchemeTokens = (key: AccentKey): { light: SchemeTokens; dark: SchemeTokens } => {
+    const a = accents[key];
+    const t = buildAccentTokens(key);
+
+    const buildShadow = (o: SchemeTokens["overlay"]): SchemeTokens["shadow"] => ({
+        nav: `0 8px 24px ${o.shadow}`,
+        card: `0 8px 24px ${t.overlayAccent.card}`,
+        button: `0 4px 12px ${t.overlayAccent.glow}`,
+        dialog: `0 24px 48px ${o.overlay}`,
+        sm: `0 1px 3px ${o.border}, 0 1px 2px ${o.hover}`,
+        md: `0 4px 16px ${o.border}, 0 2px 4px ${o.hover}`,
+    });
+
+    return {
+        dark: {
+            // Pastel accent verbatim for the dark scheme.
+            accent: {
+                main: a.pastel.main,
+                light: a.pastel.light,
+                dark: a.pastel.dark,
+                contrastText: "#0B0B0C",
+            },
+            surface: { background: "#0B0B0C", paper: "#161617" },
+            overlay: darkOverlay,
+            glass: {
+                bar: "rgba(0,0,0,0.65)", // blurred translucent AppBar background
+                border: "rgba(255,255,255,0.3)", // frosted control border (resting)
+                borderHover: "rgba(255,255,255,0.5)", // frosted control border (hover)
+                fillSubtle: "rgba(255,255,255,0.14)", // nav-link hover background
+                fill: "rgba(255,255,255,0.18)", // control fill (logo tile / button hover)
+                cta: "rgba(255,255,255,0.2)", // login CTA resting fill
+                iconHover: "rgba(255,255,255,0.28)", // logo tile hover fill
+                fillStrong: "rgba(255,255,255,0.32)", // login CTA hover fill
+                skeleton: "rgba(255,255,255,0.12)", // skeleton placeholder on the bar
+            },
+            gradient: {
+                // White → accent; the hero "gradient title" look, reused for accents elsewhere.
+                title: `linear-gradient(90deg, #FFFFFF, ${a.pastel.light})`,
+                // Home hero: warm-tinted dark diagonal base.
+                hero: "linear-gradient(135deg, #1A1416 0%, #161617 45%, #0B0B0C 100%)",
+                // Home hero: left-anchored horizontal scrim carrying the copy (must stay
+                // left-anchored at every width — see DESIGN.md §6/§13).
+                heroScrim:
+                    "linear-gradient(90deg, rgba(16,16,17,0.97) 0%, rgba(18,18,19,0.88) 40%, rgba(22,22,23,0.45) 70%, rgba(22,22,23,0) 95%)",
+                // Game Footer fades to the near-black paper surface (#161617).
+                footerFade:
+                    "linear-gradient(to bottom, rgba(22,22,23,0) 0%, rgba(22,22,23,0.6) 25%, rgba(22,22,23,1) 50%)",
+            },
+            shadow: buildShadow(darkOverlay),
+        },
+        light: {
+            // Deeper ramp so accent text/buttons clear ~4.5:1 on white, where
+            // the pastel ramp is too light to read.
+            accent: {
+                main: a.light.main, // links, contained-button bg (white text), accents
+                light: a.light.light, // accent foreground text/icons on light surfaces
+                dark: a.light.dark, // hover/emphasis
+                contrastText: "#FFFFFF",
+            },
+            // Slightly deeper warm page background so white cards/paper read as
+            // distinct raised surfaces against it.
+            surface: { background: "#EFEBE6", paper: "#FFFFFF" },
+            overlay: lightOverlay,
+            glass: {
+                bar: "rgba(249,247,245,0.9)", // mostly-opaque frosted AppBar so text stays legible
+                border: "rgba(0,0,0,0.22)", // frosted control border (resting)
+                borderHover: "rgba(0,0,0,0.38)", // frosted control border (hover)
+                fillSubtle: "rgba(0,0,0,0.06)", // nav-link hover background
+                fill: "rgba(0,0,0,0.09)", // control fill (logo tile / button hover)
+                cta: "rgba(0,0,0,0.06)", // login CTA resting fill
+                iconHover: "rgba(0,0,0,0.14)", // logo tile hover fill
+                fillStrong: "rgba(0,0,0,0.16)", // login CTA hover fill
+                skeleton: "rgba(0,0,0,0.1)", // skeleton placeholder on the bar
+            },
+            gradient: {
+                // Near-black/deep-accent → accent so the "gradient title" reads on a light surface.
+                title: `linear-gradient(90deg, ${a.lightTitleStart}, ${a.pastel.light})`,
+                // Home hero: warm-tinted light diagonal base.
+                hero: "linear-gradient(135deg, #FBEDED 0%, #F6F4F2 45%, #EFEAE6 100%)",
+                // Home hero: left-anchored horizontal scrim, light-on-light variant.
+                heroScrim:
+                    "linear-gradient(90deg, rgba(250,247,245,0.97) 0%, rgba(248,245,243,0.88) 40%, rgba(246,244,242,0.45) 70%, rgba(246,244,242,0) 95%)",
+                // Game Footer fades to the white paper surface (#FFFFFF).
+                footerFade:
+                    "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.6) 25%, rgba(255,255,255,1) 50%)",
+            },
+            shadow: buildShadow(lightOverlay),
+        },
+    };
+};

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -1,35 +1,72 @@
 import { SxProps, Theme, styled } from "@mui/material/styles";
 import ToggleButtonGroup, { toggleButtonGroupClasses } from "@mui/material/ToggleButtonGroup";
+import { timing } from "@/theme/tokens";
 
-/**
- * Responsive DataGrid container with mobile-optimized heights
- * Mobile: viewport-based height
- * Desktop: 600px
- */
 export const responsiveDataGridContainer: SxProps<Theme> = {
-    height: {
-        xs: "calc(100vh - 350px)", // Mobile: Adapt to available space
-        md: 600,
-    },
+    // dvh accounts for the mobile URL bar / browser chrome so the grid isn't
+    // sized against a viewport taller than what's actually visible.
+    height: { xs: "calc(100dvh - 320px)", md: 580 },
     width: "100%",
-    minHeight: 400, // Ensure usability even on small screens
+    minHeight: 400,
 };
 
 /**
- * Responsive card hover effects
- * Reduced transform on mobile to prevent layout shifts
+ * Text preset — the bold, fluid white→accent gradient title used for the
+ * hero heading ("UBC Mahjong Club"). Layout spacing (e.g. `mb`) is intentionally
+ * left out so it can be reused anywhere; spread it and add margins as needed:
+ *   <Typography variant="h1" sx={{ ...gradientTitle, mb: 2.5 }}>…</Typography>
  */
+export const gradientTitle: SxProps<Theme> = {
+    fontWeight: 800,
+    fontSize: { xs: "2rem", sm: "2.6rem", md: "3.15rem" },
+    lineHeight: 1.15,
+    pb: "0.08em",
+    letterSpacing: "-0.02em",
+    background: "var(--mui-palette-gradient-title)",
+    backgroundClip: "text",
+    WebkitBackgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+};
+
+/**
+ * Eyebrow / overline label preset — the small, uppercase, letter-spaced caps
+ * used to title sections and table columns (e.g. "Score", "Game Actions",
+ * drawer section headers). Spread it and layer on spacing/overrides as needed:
+ *   <Typography sx={{ ...eyebrowLabel, mb: 0.5 }}>…</Typography>
+ */
+export const eyebrowLabel: SxProps<Theme> = {
+    display: "block",
+    fontWeight: 700,
+    fontSize: "0.78rem",
+    textTransform: "uppercase",
+    letterSpacing: "0.08em",
+    color: "text.secondary",
+};
+
 export const responsiveCardHover: SxProps<Theme> = {
-    transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+    position: "relative",
+    overflow: "hidden",
+    transition: `all ${timing.slow} ${timing.ease}`,
+    "&::after": {
+        content: '""',
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: "2px",
+        background: `linear-gradient(90deg, var(--mui-palette-primary-light), transparent)`,
+        transform: "scaleX(0)",
+        transformOrigin: "left",
+        transition: `transform 0.25s ${timing.ease}`,
+    },
     "&:hover": {
-        transform: { xs: "none", sm: "translateY(-4px)" },
-        boxShadow: { xs: 2, sm: 6 },
+        transform: { xs: "none", sm: "translateY(-3px)" },
+        boxShadow: { xs: "none", sm: "var(--mui-palette-appShadow-card)" },
+        borderColor: "primary.light",
+        "&::after": { transform: "scaleX(1)" },
     },
 };
 
-/**
- * Responsive text truncation with overflow handling
- */
 export const responsiveTextTruncate: SxProps<Theme> = {
     overflow: "hidden",
     textOverflow: "ellipsis",
@@ -37,16 +74,20 @@ export const responsiveTextTruncate: SxProps<Theme> = {
     maxWidth: { xs: "200px", sm: "300px", md: "100%" },
 };
 
-/**
- * Shared navbar button styling - overrides theme defaults for compact nav buttons
- */
 export const navButton: SxProps<Theme> = {
     minWidth: "auto",
     minHeight: "auto",
-    padding: "6px 8px",
-    borderRadius: 1,
-    fontSize: "1rem",
+    padding: "5px 10px",
+    borderRadius: 1.5,
+    fontSize: "0.875rem",
+    fontWeight: 500,
     whiteSpace: "nowrap",
+    color: "inherit",
+    transition: "background 0.12s, color 0.12s",
+    "&:hover": {
+        background: "var(--mui-palette-glass-fillSubtle)",
+        transform: "none",
+    },
 };
 
 export const SpacedToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({


### PR DESCRIPTION
Introduces the platform layer the rest of the UI overhaul sits on, with no feature redesigns yet:

- theme/tokens.ts: single source of truth for accent ramps (red/blue/green), per-scheme neutrals, medal/placement colors, and timing.
- theme/index.ts: createAppTheme(accent) builds a colorSchemes (light/dark) theme, exposing accent + neutrals as CSS vars (--mui-palette-*).
- theme/AccentContext.tsx: runtime accent switch (localStorage-persisted), orthogonal to MUI's color-scheme mode.
- theme/utils.ts: additive sx presets (gradientTitle, eyebrowLabel) plus restyled existing helpers; export names/types unchanged so current components keep compiling.
- index.tsx: InitColorSchemeScript to avoid a flash of the wrong theme.
- index.html: load the Manrope font used by the theme typography.
- App.tsx: swap ThemeProvider(createAppTheme()) for <AccentProvider> only; routing is left untouched here and migrated in later PRs.
- DESIGN.md: design-system reference. Fixed the tokens.ts docstring drift (was "two accent variants"; there are three: red/blue/green).

Typechecks independently (tsc --noEmit clean) with the still-un-migrated components consuming the new theme.