### PR TITLE
Consolidate leaderboard into one query-param page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,28 +62,44 @@ const App = () => {
                             <Routes>
                                 <Route element={<WithNav />}>
                                     <Route path="/" element={<Home />} />
+                                    <Route path="/leaderboard" element={<Leaderboard />} />
+                                    {/* Legacy per-board leaderboard URLs now redirect to the
+                                        single condensed page, carrying the intended board so it
+                                        opens on that selection. */}
                                     <Route
                                         path="/leaderboard/jp"
                                         element={
-                                            <Leaderboard gameVariant="jp" gameType={"RANKED"} />
+                                            <Navigate
+                                                to="/leaderboard?variant=jp&type=RANKED"
+                                                replace
+                                            />
                                         }
                                     />
                                     <Route
                                         path="/leaderboard/jp/casual"
                                         element={
-                                            <Leaderboard gameVariant="jp" gameType={"CASUAL"} />
+                                            <Navigate
+                                                to="/leaderboard?variant=jp&type=CASUAL"
+                                                replace
+                                            />
                                         }
                                     />
                                     <Route
                                         path="/leaderboard/hk"
                                         element={
-                                            <Leaderboard gameVariant="hk" gameType={"RANKED"} />
+                                            <Navigate
+                                                to="/leaderboard?variant=hk&type=RANKED"
+                                                replace
+                                            />
                                         }
                                     />
                                     <Route
                                         path="/leaderboard/hk/casual"
                                         element={
-                                            <Leaderboard gameVariant="hk" gameType={"CASUAL"} />
+                                            <Navigate
+                                                to="/leaderboard?variant=hk&type=CASUAL"
+                                                replace
+                                            />
                                         }
                                     />
                                     <Route path="/games/:variant/:id" element={<Game />} />

--- a/frontend/src/leaderboard/Leaderboard.tsx
+++ b/frontend/src/leaderboard/Leaderboard.tsx
@@ -1,6 +1,7 @@
-import type { GameCreationProp, Season, GameVariant, GameType, LeaderboardType } from "@/types";
-
+import type { Season, GameVariant, GameType, LeaderboardType } from "@/types";
+import { palette as tokens } from "@/theme/tokens";
 import { memo, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { getGameVariantString } from "@/common/Utils";
 import { useSeasons } from "@/hooks/AdminHooks";
 import { usePlayerLeaderboard } from "@/hooks/LeaderboardHooks";
@@ -10,11 +11,13 @@ import { GridColDef, DataGrid } from "@mui/x-data-grid";
 import {
     Autocomplete,
     Box,
+    Chip,
     Container,
     Dialog,
     DialogContent,
     DialogTitle,
     IconButton,
+    MenuItem,
     Stack,
     TextField,
     Typography,
@@ -22,48 +25,116 @@ import {
     useTheme,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import { DisplayStatistics } from "@/statistics/Statistics";
 
-const Leaderboard = <T extends GameVariant>({ gameVariant, gameType }: GameCreationProp<T>) => {
+// The four available leaderboards, ordered to match the NavBar dropdown. The
+// first entry (Riichi Ranked) is the default shown when the page opens.
+const LEADERBOARD_OPTIONS = [
+    { gameVariant: "jp", gameType: "RANKED" },
+    { gameVariant: "jp", gameType: "CASUAL" },
+    { gameVariant: "hk", gameType: "RANKED" },
+    { gameVariant: "hk", gameType: "CASUAL" },
+] as const satisfies readonly { gameVariant: GameVariant; gameType: GameType }[];
+
+const optionKey = (gameVariant: GameVariant, gameType: GameType) => `${gameVariant}-${gameType}`;
+
+// Resolve the active board from the URL (so NavBar deep-links land on the right
+// one), falling back to the default Riichi Ranked board.
+const resolveOption = (variant: string | null, type: string | null) =>
+    LEADERBOARD_OPTIONS.find((o) => o.gameVariant === variant && o.gameType === type) ??
+    LEADERBOARD_OPTIONS[0];
+
+const Leaderboard = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selected = resolveOption(searchParams.get("variant"), searchParams.get("type"));
+    const { gameVariant, gameType } = selected;
+
     const [season, setSeason] = useState<Season | null>(null);
     const { isSuccess: seasonsSuccess, data: seasons } = useSeasons();
 
     useEffect(() => {
-        // Set the currently active season, or fallback to the most recent season
         if (seasonsSuccess && seasons && seasons.length > 0) {
             const now = new Date();
-            const activeSeason = seasons.find(
+            const active = seasons.find(
                 (s) => new Date(s.startDate) <= now && now < new Date(s.endDate),
             );
-            setSeason(activeSeason ?? seasons[0]);
+            setSeason(active ?? seasons[0]);
         }
     }, [seasonsSuccess, seasons]);
 
     if (!seasonsSuccess) {
-        return <LoadingFallback minHeight="50vh" message="Loading seasons..." />;
+        return <LoadingFallback minHeight="50vh" message="Loading seasons…" />;
     }
+
     return (
         <Container>
-            <Stack>
-                <Typography variant="h1">
-                    {getGameVariantString(gameVariant, gameType)} Leaderboard
-                </Typography>
-
-                <Autocomplete
-                    isOptionEqualToValue={(option, value) => option.id === value.id}
-                    getOptionLabel={(option) => option.name}
-                    options={seasons}
-                    value={season!}
-                    blurOnSelect
-                    disableClearable
-                    onChange={(_e, value) => setSeason(value)}
-                    renderInput={(params) => (
-                        <TextField {...params} label="Season" placeholder="Select a season" />
+            <Stack spacing={3}>
+                <Box>
+                    <Typography variant="h1" gutterBottom>
+                        {getGameVariantString(gameVariant, gameType)} Leaderboard
+                    </Typography>
+                    {season && (
+                        <Typography variant="body2" color="text.secondary">
+                            Season ends{" "}
+                            {new Date(season.endDate).toLocaleDateString("en-US", {
+                                month: "long",
+                                day: "numeric",
+                                year: "numeric",
+                            })}
+                        </Typography>
                     )}
-                />
+                </Box>
+
+                <Stack
+                    direction="row"
+                    spacing={{ xs: 1.5, sm: 2 }}
+                    sx={{ width: "100%" }}
+                >
+                    <Autocomplete
+                        isOptionEqualToValue={(o, v) => o.id === v.id}
+                        getOptionLabel={(o) => o.name}
+                        options={seasons}
+                        value={season!}
+                        blurOnSelect
+                        disableClearable
+                        onChange={(_e, v) => setSeason(v)}
+                        sx={{ flex: 1, minWidth: 0 }}
+                        renderInput={(params) => (
+                            <TextField {...params} label="Season" placeholder="Select a season" />
+                        )}
+                    />
+
+                    <TextField
+                        select
+                        label="Leaderboard"
+                        value={optionKey(gameVariant, gameType)}
+                        onChange={(e) => {
+                            const next = LEADERBOARD_OPTIONS.find(
+                                (o) => optionKey(o.gameVariant, o.gameType) === e.target.value,
+                            )!;
+                            setSearchParams(
+                                { variant: next.gameVariant, type: next.gameType },
+                                { replace: true },
+                            );
+                        }}
+                        sx={{ flex: 1, minWidth: 0, "& .MuiSelect-select": { textAlign: "left" } }}
+                    >
+                        {LEADERBOARD_OPTIONS.map((o) => (
+                            <MenuItem
+                                key={optionKey(o.gameVariant, o.gameType)}
+                                value={optionKey(o.gameVariant, o.gameType)}
+                            >
+                                {getGameVariantString(o.gameVariant, o.gameType)}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+                </Stack>
 
                 {!season ? (
-                    <Typography variant="body1">No season selected</Typography>
+                    <Typography variant="body1" color="text.secondary">
+                        No season selected
+                    </Typography>
                 ) : (
                     <LeaderboardDisplay
                         season={season}
@@ -76,43 +147,94 @@ const Leaderboard = <T extends GameVariant>({ gameVariant, gameType }: GameCreat
     );
 };
 
+const MEDAL_STYLES = [tokens.medal.gold, tokens.medal.silver, tokens.medal.bronze] as const;
+
+const rankCell = (params: { value: number }) => {
+    if (params.value >= 1 && params.value <= 3) {
+        const { text, bg } = MEDAL_STYLES[params.value - 1];
+        return (
+            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%" }}>
+                <Box
+                    sx={{
+                        width: 28,
+                        height: 28,
+                        borderRadius: "50%",
+                        bgcolor: bg,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontWeight: 700,
+                        fontSize: "0.8rem",
+                        color: text,
+                    }}
+                >
+                    {params.value}
+                </Box>
+            </Box>
+        );
+    }
+    return (
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", color: "text.secondary", fontSize: "0.85rem" }}>
+            {params.value}
+        </Box>
+    );
+};
+
+const eloCell = (params: { value: string }) => (
+    <Box sx={{ display: "flex", alignItems: "center", justifyContent: "flex-end", height: "100%" }}>
+        <Typography variant="body2" fontWeight={600} fontVariantNumeric="tabular-nums">
+            {params.value}
+        </Typography>
+    </Box>
+);
+
+const chomboCell = (params: { value: number }) =>
+    params.value > 0 ? (
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "flex-end", height: "100%" }}>
+            <Chip
+                label={params.value}
+                size="small"
+                color="error"
+                variant="outlined"
+                sx={{ fontWeight: 700, fontSize: "0.7rem", height: 20 }}
+            />
+        </Box>
+    ) : (
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "flex-end", height: "100%", color: "text.disabled" }}>
+            {params.value}
+        </Box>
+    );
+
 const columns: GridColDef[] = [
     {
         field: "index",
         headerName: "#",
         type: "number",
-        width: 60,
+        width: 64,
         minWidth: 50,
         disableColumnMenu: true,
+        renderCell: rankCell,
     },
-    {
-        field: "username",
-        headerName: "Player",
-        flex: 1,
-        minWidth: 120,
-    },
+    { field: "username", headerName: "Player", flex: 1, minWidth: 130 },
     {
         field: "displayElo",
         headerName: "Elo",
         type: "number",
-        width: 90,
+        width: 100,
         minWidth: 80,
+        renderCell: eloCell,
     },
-    {
-        field: "gameCount",
-        headerName: "Games",
-        type: "number",
-        width: 80,
-        minWidth: 70,
-    },
+    { field: "gameCount", headerName: "Games", type: "number", width: 85, minWidth: 70 },
     {
         field: "chomboCount",
         headerName: "Chombos",
         type: "number",
-        width: 90,
+        width: 100,
         minWidth: 80,
+        renderCell: chomboCell,
     },
 ];
+
 const LeaderboardDisplay = memo(
     ({
         gameVariant,
@@ -123,45 +245,28 @@ const LeaderboardDisplay = memo(
         gameType: GameType;
         season: Season;
     }) => {
-        const { isSuccess, data: leaderboard } = usePlayerLeaderboard(
-            gameVariant,
-            gameType,
-            season,
-        );
+        const { isSuccess, data: leaderboard } = usePlayerLeaderboard(gameVariant, gameType, season);
         const [player, setPlayer] = useState<LeaderboardType | undefined>(undefined);
         const theme = useTheme();
         const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
         if (!isSuccess) {
-            return <LoadingFallback minHeight="30vh" message="Loading leaderboard..." />;
+            return <LoadingFallback minHeight="30vh" message="Loading leaderboard…" />;
         }
 
         return (
             <>
-                <Typography variant="body1" color="text.secondary">
-                    {season.name} ends {new Date(season.endDate).toDateString()}
-                </Typography>
                 <Box sx={responsiveDataGridContainer}>
                     <DataGrid<(typeof leaderboard)[0]>
                         rows={leaderboard}
                         columns={columns}
                         initialState={{
                             columns: {
-                                columnVisibilityModel: {
-                                    chomboCount: !isMobile,
-                                },
+                                columnVisibilityModel: { chomboCount: false },
                             },
                         }}
-                        onRowClick={(params) => isMobile && setPlayer(params.row)}
-                        onRowDoubleClick={(params) => !isMobile && setPlayer(params.row)}
-                        sx={{
-                            "& .MuiDataGrid-cell": {
-                                cursor: "pointer",
-                            },
-                            "& .MuiDataGrid-row:hover": {
-                                backgroundColor: theme.palette.action.hover,
-                            },
-                        }}
+                        onRowClick={(p) => isMobile && setPlayer(p.row)}
+                        onRowDoubleClick={(p) => !isMobile && setPlayer(p.row)}
                         disableColumnMenu={isMobile}
                         density={isMobile ? "compact" : "standard"}
                     />
@@ -169,6 +274,7 @@ const LeaderboardDisplay = memo(
                 <Typography variant="caption" color="text.secondary">
                     {isMobile ? "Tap" : "Double-click"} a row to view detailed statistics
                 </Typography>
+
                 <Dialog
                     open={player !== undefined}
                     onClose={() => setPlayer(undefined)}
@@ -183,16 +289,20 @@ const LeaderboardDisplay = memo(
                                     display: "flex",
                                     alignItems: "center",
                                     justifyContent: "space-between",
+                                    pb: 1,
                                 }}
                             >
-                                Statistics for {player.username}
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                    <EmojiEventsIcon color="primary" fontSize="small" />
+                                    <span>Statistics — {player.username}</span>
+                                </Stack>
                                 <IconButton
                                     edge="end"
-                                    color="inherit"
                                     onClick={() => setPlayer(undefined)}
                                     aria-label="close"
+                                    size="small"
                                 >
-                                    <CloseIcon />
+                                    <CloseIcon fontSize="small" />
                                 </IconButton>
                             </DialogTitle>
                             <DialogContent>
@@ -209,5 +319,6 @@ const LeaderboardDisplay = memo(
         );
     },
 );
+
 LeaderboardDisplay.displayName = "LeaderboardDisplay";
 export default Leaderboard;


### PR DESCRIPTION
Collapse the four prop-driven per-board routes into a single /leaderboard page that reads ?variant=&type= via useSearchParams and lets the user switch boards in-page. Legacy URLs (/leaderboard/jp, .../casual, /leaderboard/hk, ...) now redirect with the intended board carried in the query string, so existing links/bookmarks still land on the right selection.

App.tsx changes are scoped to the leaderboard routes; games/create routing is migrated in later PRs.