### PR TITLE
Consolidate live games + logs into one Games page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,9 +14,7 @@ import Tournament from "./resources/Tournament";
 // Lazy load route components for code splitting
 const Home = React.lazy(() => import("./home/Home"));
 const Leaderboard = React.lazy(() => import("./leaderboard/Leaderboard"));
-const LiveGames = React.lazy(() =>
-    import("./game/LiveGames").then((module) => ({ default: module.LiveGames })),
-);
+const Games = React.lazy(() => import("./game/Games"));
 const CreateGame = React.lazy(() => import("./game/CreateGame"));
 const Game = React.lazy(() => import("./game/Game"));
 const Statistics = React.lazy(() => import("./statistics/Statistics"));
@@ -30,7 +28,6 @@ const PasswordReset = React.lazy(() => import("./login/PasswordReset"));
 const Resources = React.lazy(() =>
     import("./resources/Resources").then((module) => ({ default: module.Resources })),
 );
-const GameLogs = React.lazy(() => import("./game/GameLogs"));
 
 // Create QueryClient outside component to prevent recreation on every render
 const queryClient = new QueryClient({
@@ -103,14 +100,7 @@ const App = () => {
                                         }
                                     />
                                     <Route path="/games/:variant/:id" element={<Game />} />
-                                    <Route
-                                        path="/games/current/jp"
-                                        element={<LiveGames gameVariant="jp" gameType={"RANKED"} />}
-                                    />
-                                    <Route
-                                        path="/games/current/hk"
-                                        element={<LiveGames gameVariant="hk" gameType={"RANKED"} />}
-                                    />
+                                    <Route path="/games/current" element={<Games />} />
                                     <Route
                                         path="/games/create/jp"
                                         element={
@@ -136,7 +126,7 @@ const App = () => {
                                         }
                                     />
                                     <Route path="/games/not-found" element={<GameNotFound />} />
-                                    <Route path="/games" element={<GameLogs />} />
+                                    <Route path="/games" element={<Games />} />
                                     <Route path="/resources" element={<Resources />} />
                                     <Route path="/vro2026" element={<Tournament />} />
                                     <Route

--- a/frontend/src/common/Utils.ts
+++ b/frontend/src/common/Utils.ts
@@ -118,6 +118,22 @@ const range = (end: number): number[] => {
     return Array.from({ length: end }, (_, i) => i);
 };
 
+/** "Just now" / "5m ago" / "3h ago", falling back to an absolute date past 24h. */
+export const formatRelativeTime = (dateString: string): string => {
+    const date = new Date(dateString);
+    const diffMins = Math.floor((Date.now() - date.getTime()) / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffMins < 1) return "Just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    return date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+};
+
 export function getRiichiStickCount(rounds: JapaneseRound[], riichiList: number[]) {
     if (rounds.length === 0) {
         return 0;

--- a/frontend/src/game/GameLogs.tsx
+++ b/frontend/src/game/GameLogs.tsx
@@ -5,9 +5,7 @@ import { logger } from "@/common/logger";
 import {
     Box,
     Card,
-    CardActionArea,
     CardContent,
-    Container,
     Grid,
     Typography,
     Autocomplete,
@@ -15,79 +13,77 @@ import {
     TextField,
     CircularProgress,
     Pagination,
-    CardHeader,
     Stack,
+    Collapse,
+    IconButton,
 } from "@mui/material";
-import { Link } from "react-router-dom";
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import SearchIcon from "@mui/icons-material/Search";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import alert from "@/common/AlertDialog";
-import GameSummaryBody from "./common/GameSummaryBody";
+import GameSummaryCard, { gameSummaryGrid } from "./common/GameSummaryCard";
+import GameSectionHeader from "./common/GameSectionHeader";
 import { useSeasons } from "@/hooks/AdminHooks";
 import { usePlayers } from "@/hooks/GameHooks";
-import { getGameVariantString } from "@/common/Utils";
 import type { GameVariant, Season, Game, PlayerNamesDataType } from "@/types";
-import { responsiveCardHover } from "@/theme/utils";
-
-const gameVariants = [
-    { name: "Riichi", variant: "jp" },
-    { name: "Hong Kong", variant: "hk" },
-] as const;
 
 const MAX_GAMES_PER_PAGE = 12;
 
-const GameLogs = <T extends GameVariant>() => {
-    const [queryGameVariant, setQueryGameVariant] = useState<GameVariant>(gameVariants[0].variant);
+const GameLogsSection = <T extends GameVariant>({ gameVariant }: { gameVariant: T }) => {
     const [season, setSeason] = useState<Season | null>(null);
     const [queryPlayers, setQueryPlayers] = useState<PlayerNamesDataType[]>([]);
 
     const [loading, setLoading] = useState(false);
     const [games, setGames] = useState<Game<T>[]>([]);
     const [pagination, setPagination] = useState<number>(1);
+    const [expanded, setExpanded] = useState(false);
 
     const { isSuccess: seasonsSuccess, data: seasons } = useSeasons();
-    const playersResult = usePlayers(queryGameVariant, "CASUAL");
+    const playersResult = usePlayers(gameVariant, "CASUAL");
 
     const seasonsSorted =
         seasonsSuccess && seasons ? [...seasons].sort((a, b) => b.id.localeCompare(a.id)) : [];
+
     useEffect(() => {
-        // Always set the first season (most recent) as the default season if available
-        if (!season && seasonsSorted.length > 0) {
-            setSeason(seasonsSorted[0]);
-        }
+        if (!season && seasonsSorted.length > 0) setSeason(seasonsSorted[0]);
     }, [seasonsSorted]);
 
-    const disableQueryButton = useCallback((): boolean => {
-        return loading || season === null;
-    }, [loading, season]);
+    // Player lists and results are variant-specific — clear them when the
+    // shared variant toggle changes so stale data isn't shown.
+    useEffect(() => {
+        setQueryPlayers([]);
+        setGames([]);
+        setPagination(1);
+    }, [gameVariant]);
+
+    const disableQueryButton = useCallback(
+        () => loading || season === null,
+        [loading, season],
+    );
 
     const getGames = useCallback(async () => {
         if (season !== null) {
             setLoading(true);
             try {
                 const response = await getGamesAPI(
-                    queryGameVariant,
+                    gameVariant,
                     season.id,
                     queryPlayers.map((p) => p.playerId),
                 );
                 response.data.reverse();
                 setGames(response.data);
-                setLoading(false);
                 setPagination(1);
-                if (response.data.length === 0) {
-                    alert("No games found");
-                }
+                if (response.data.length === 0) alert("No games found");
             } catch (error) {
                 logger.error("Error fetching games: ", (error as AxiosError).response?.data);
+            } finally {
                 setLoading(false);
             }
         }
-    }, [queryGameVariant, season, queryPlayers]);
+    }, [gameVariant, season, queryPlayers]);
 
     const getPaginatedGames = () => {
-        const startIdx = (pagination - 1) * MAX_GAMES_PER_PAGE;
-        const endIdx = Math.min(pagination * MAX_GAMES_PER_PAGE, games.length);
-
-        return games.slice(startIdx, endIdx);
+        const start = (pagination - 1) * MAX_GAMES_PER_PAGE;
+        return games.slice(start, start + MAX_GAMES_PER_PAGE);
     };
 
     const formatDate = (dateString: string) => {
@@ -101,198 +97,122 @@ const GameLogs = <T extends GameVariant>() => {
         });
     };
 
-    if (!seasonsSuccess || !playersResult.isSuccess) {
-        return (
-            <Container maxWidth="lg" sx={{ mt: 4, display: "flex", justifyContent: "center" }}>
-                <CircularProgress />
-            </Container>
-        );
-    }
-
-    const players = playersResult.data.sort((a, b) => a.username.localeCompare(b.username));
+    const players = (playersResult.data ?? []).sort((a, b) => a.username.localeCompare(b.username));
     const numPages = Math.ceil(games.length / MAX_GAMES_PER_PAGE);
 
     return (
-        <Container>
-            <Stack spacing={3}>
-                <Typography variant="h1" align="center">
-                    Game Logs
-                </Typography>
+        <Stack spacing={3}>
+            <GameSectionHeader title="Logs" onClick={() => setExpanded((prev) => !prev)}>
+                <IconButton
+                    aria-label={expanded ? "Collapse game logs" : "Expand game logs"}
+                    aria-expanded={expanded}
+                    sx={{
+                        transition: "transform 0.2s",
+                        transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                    }}
+                >
+                    <ExpandMoreIcon />
+                </IconButton>
+            </GameSectionHeader>
 
-                {/* Search Filters */}
-                <Card>
-                    <CardContent>
-                        <Stack spacing={2}>
-                            <Grid container spacing={3}>
-                                <Grid size={{ xs: 12, md: 4 }}>
-                                    <Autocomplete
-                                        options={gameVariants}
-                                        getOptionLabel={(option) => option.name}
-                                        isOptionEqualToValue={(option, value) =>
-                                            option.variant === value.variant
-                                        }
-                                        blurOnSelect
-                                        value={
-                                            gameVariants.find(
-                                                (g) => g.variant === queryGameVariant,
-                                            ) || gameVariants[0]
-                                        }
-                                        onChange={(_e, value) =>
-                                            value && setQueryGameVariant(value.variant)
-                                        }
-                                        disableClearable
-                                        renderInput={(params) => (
-                                            <TextField {...params} label="Game Variant" />
-                                        )}
-                                    />
-                                </Grid>
-                                <Grid size={{ xs: 12, md: 4 }}>
-                                    <Autocomplete
-                                        options={seasonsSorted}
-                                        getOptionLabel={(option) => option.name}
-                                        isOptionEqualToValue={(option, value) =>
-                                            option.id === value.id
-                                        }
-                                        value={season!}
-                                        blurOnSelect
-                                        disableClearable
-                                        onChange={(_e, value) => setSeason(value)}
-                                        renderInput={(params) => (
-                                            <TextField
-                                                {...params}
-                                                label="Season"
-                                                placeholder="Select a season"
-                                            />
-                                        )}
-                                    />
-                                </Grid>
-                                <Grid size={{ xs: 12, md: 4 }}>
-                                    <Autocomplete
-                                        options={players}
-                                        getOptionLabel={(option) => option.username}
-                                        isOptionEqualToValue={(option, value) =>
-                                            option.playerId === value.playerId
-                                        }
-                                        value={queryPlayers}
-                                        onChange={(_e, value) => setQueryPlayers(value)}
-                                        multiple
-                                        disableCloseOnSelect
-                                        renderInput={(params) => (
-                                            <TextField
-                                                {...params}
-                                                label="Players"
-                                                placeholder="Filter by players (optional)"
-                                            />
-                                        )}
-                                    />
-                                </Grid>
+            <Collapse in={expanded} timeout="auto" unmountOnExit>
+                {!seasonsSuccess || !playersResult.isSuccess ? (
+                    <Box sx={{ py: 4, display: "flex", justifyContent: "center" }}>
+                        <CircularProgress />
+                    </Box>
+                ) : (
+                    <Stack spacing={3}>
+                        {/* Filters */}
+                        <Card sx={{ overflow: "visible" }}>
+                <CardContent sx={{ p: { xs: 2, md: 2.5 } }}>
+                    <Stack spacing={2}>
+                        <Grid container spacing={2}>
+                            <Grid size={{ xs: 12, md: 6 }}>
+                                <Autocomplete
+                                    options={seasonsSorted}
+                                    getOptionLabel={(o) => o.name}
+                                    isOptionEqualToValue={(o, v) => o.id === v.id}
+                                    value={season!}
+                                    blurOnSelect
+                                    disableClearable
+                                    onChange={(_e, v) => setSeason(v)}
+                                    renderInput={(params) => (
+                                        <TextField {...params} label="Season" placeholder="Select a season" />
+                                    )}
+                                />
                             </Grid>
+                            <Grid size={{ xs: 12, md: 6 }}>
+                                <Autocomplete
+                                    options={players}
+                                    getOptionLabel={(o) => o.username}
+                                    isOptionEqualToValue={(o, v) => o.playerId === v.playerId}
+                                    value={queryPlayers}
+                                    onChange={(_e, v) => setQueryPlayers(v)}
+                                    multiple
+                                    disableCloseOnSelect
+                                    renderInput={(params) => (
+                                        <TextField {...params} label="Players" placeholder="Filter by players" />
+                                    )}
+                                />
+                            </Grid>
+                        </Grid>
 
-                            <Box display="flex" justifyContent="center">
+                            <Box display="flex" justifyContent={{ xs: "stretch", sm: "flex-end" }}>
                                 <Button
                                     variant="contained"
                                     disabled={disableQueryButton()}
                                     onClick={getGames}
                                     size="large"
+                                    startIcon={loading ? <CircularProgress size={16} color="inherit" /> : <SearchIcon />}
+                                    sx={{ minWidth: { xs: "100%", sm: 160 } }}
                                 >
-                                    {loading ? "Searching..." : "Search Games"}
+                                    {loading ? "Searching…" : "Search Games"}
                                 </Button>
                             </Box>
                         </Stack>
                     </CardContent>
                 </Card>
 
-                {/* Game Cards */}
-                <Grid container spacing={3}>
+                {/* Results count */}
+                {games.length > 0 && (
+                    <Typography variant="body2" color="text.secondary">
+                        {games.length} game{games.length !== 1 ? "s" : ""} found
+                    </Typography>
+                )}
+
+                {/* Game cards */}
+                <Box sx={gameSummaryGrid}>
                     {getPaginatedGames().map((game) => (
-                        <Grid size={{ xs: 12, md: 6 }} key={game.id}>
-                            <Card
-                                sx={{
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    ...responsiveCardHover,
-                                }}
-                            >
-                                <CardActionArea
-                                    component={Link}
-                                    to={`/games/${queryGameVariant}/${game.id}`}
-                                    sx={{
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        alignItems: "stretch",
-                                        flexGrow: 1,
-                                    }}
-                                >
-                                    <CardHeader
-                                        title={
-                                            <Box
-                                                sx={{
-                                                    display: "flex",
-                                                    alignItems: "center",
-                                                    justifyContent: "space-between",
-                                                    flexWrap: "wrap",
-                                                }}
-                                            >
-                                                <Typography variant="h6" component="div">
-                                                    {getGameVariantString(
-                                                        queryGameVariant,
-                                                        game.type,
-                                                    )}{" "}
-                                                    #{game.id}
-                                                </Typography>
-                                            </Box>
-                                        }
-                                        subheader={
-                                            <Box
-                                                sx={{
-                                                    display: "flex",
-                                                    alignItems: "center",
-                                                    gap: 0.5,
-                                                    mt: 1,
-                                                }}
-                                            >
-                                                <CalendarTodayIcon fontSize="small" />
-                                                <Typography variant="caption">
-                                                    {formatDate(game.createdAt)}
-                                                </Typography>
-                                            </Box>
-                                        }
-                                        sx={{
-                                            bgcolor: "action.hover",
-                                            "& .MuiCardHeader-subheader": {
-                                                color: "text.secondary",
-                                            },
-                                        }}
-                                    />
-                                    <CardContent sx={{ flexGrow: 1 }}>
-                                        <GameSummaryBody
-                                            game={game}
-                                            gameVariant={queryGameVariant}
-                                        />
-                                    </CardContent>
-                                </CardActionArea>
-                            </Card>
-                        </Grid>
+                        <GameSummaryCard
+                            key={game.id}
+                            variant="log"
+                            game={game}
+                            gameVariant={gameVariant}
+                            chipLabel={game.type}
+                            timeText={formatDate(game.createdAt)}
+                        />
                     ))}
-                </Grid>
+                </Box>
 
                 {/* Pagination */}
                 {games.length > MAX_GAMES_PER_PAGE && (
-                    <Box display="flex" justifyContent="center">
+                    <Box display="flex" justifyContent="center" pt={1}>
                         <Pagination
                             count={numPages}
                             page={pagination}
-                            onChange={(event, page) => setPagination(page)}
+                            onChange={(_e, p) => setPagination(p)}
                             color="primary"
                             size="large"
                             showFirstButton
                             showLastButton
                         />
                     </Box>
+                        )}
+                    </Stack>
                 )}
-            </Stack>
-        </Container>
+            </Collapse>
+        </Stack>
     );
 };
 
-export default GameLogs;
+export default GameLogsSection;

--- a/frontend/src/game/Games.tsx
+++ b/frontend/src/game/Games.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import {
+    Container,
+    Divider,
+    Stack,
+    ToggleButton,
+    ToggleButtonGroup,
+} from "@mui/material";
+import { getGameVariantString } from "@/common/Utils";
+import { LiveGamesSection } from "./LiveGames";
+import GameLogsSection from "./GameLogs";
+import GameSectionHeader from "./common/GameSectionHeader";
+import type { GameVariant } from "@/types";
+
+// Page header with the title and the shared Riichi/Hong Kong variant selector
+// that drives both the live games and the game logs sections below.
+const GamesHeader = ({
+    variant,
+    onChange,
+}: {
+    variant: GameVariant;
+    onChange: (v: GameVariant) => void;
+}) => (
+    <GameSectionHeader title="Games">
+        <ToggleButtonGroup
+            exclusive
+            size="medium"
+            value={variant}
+            onChange={(_e, v) => v && onChange(v as GameVariant)}
+            aria-label="game variant"
+            sx={{
+                width: { xs: "100%", sm: "auto" },
+                minWidth: { sm: 320 },
+                "& .MuiToggleButton-root": {
+                    flex: 1,
+                    px: 4,
+                    py: 1.25,
+                    fontSize: "1.05rem",
+                    fontWeight: 600,
+                    textTransform: "none",
+                },
+                "& .MuiToggleButtonGroup-firstButton": {
+                    borderTopLeftRadius: 20,
+                    borderBottomLeftRadius: 20,
+                },
+                "& .MuiToggleButtonGroup-lastButton": {
+                    borderTopRightRadius: 20,
+                    borderBottomRightRadius: 20,
+                },
+            }}
+        >
+            <ToggleButton value="jp">{getGameVariantString("jp")}</ToggleButton>
+            <ToggleButton value="hk">{getGameVariantString("hk")}</ToggleButton>
+        </ToggleButtonGroup>
+    </GameSectionHeader>
+);
+
+const Games = () => {
+    const [gameVariant, setGameVariant] = useState<GameVariant>("jp");
+
+    return (
+        <Container maxWidth="lg">
+            <Stack spacing={4}>
+                <Stack spacing={3}>
+                    <GamesHeader variant={gameVariant} onChange={setGameVariant} />
+                    <LiveGamesSection gameVariant={gameVariant} />
+                </Stack>
+
+                <Divider />
+
+                <GameLogsSection gameVariant={gameVariant} />
+            </Stack>
+        </Container>
+    );
+};
+
+export default Games;

--- a/frontend/src/game/LiveGames.tsx
+++ b/frontend/src/game/LiveGames.tsx
@@ -1,154 +1,71 @@
-import {
-    Box,
-    Card,
-    CardContent,
-    CardHeader,
-    Chip,
-    Container,
-    Grid,
-    Typography,
-    CircularProgress,
-    Alert,
-    Stack,
-    CardActionArea,
-} from "@mui/material";
-import { Link } from "react-router-dom";
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
-import { getGameVariantString } from "@/common/Utils";
+import { Box, Card, Skeleton, Alert } from "@mui/material";
 import { gameRoundString } from "./common/constants";
-import GameSummaryBody from "./common/GameSummaryBody";
+import GameSummaryCard, { gameSummaryGrid } from "./common/GameSummaryCard";
 import { useLiveGames } from "@/hooks/GameHooks";
-import type { GameCreationProp, GameVariant } from "@/types";
-import { responsiveCardHover } from "@/theme/utils";
+import { formatRelativeTime } from "@/common/Utils";
+import type { GameVariant } from "@/types";
 
-export const LiveGames = <T extends GameVariant>({ gameVariant }: GameCreationProp<T>) => {
+const LiveGamesSkeleton = () => (
+    <Box sx={gameSummaryGrid}>
+        {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i} sx={{ display: "flex", flexDirection: "column" }}>
+                <Box sx={{ bgcolor: "action.hover", px: 2, py: 1.75, display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                    <Skeleton variant="text" width="45%" height={32} />
+                    <Skeleton variant="rounded" width={90} height={36} />
+                </Box>
+                <Box sx={{ p: 1.5 }}>
+                    {Array.from({ length: 4 }).map((__, r) => (
+                        <Skeleton key={r} variant="rounded" height={36} sx={{ my: 0.75 }} />
+                    ))}
+                </Box>
+            </Card>
+        ))}
+    </Box>
+);
+
+export const LiveGamesSection = ({ gameVariant }: { gameVariant: GameVariant }) => {
     const { isPending, error, data: liveGames } = useLiveGames(gameVariant);
 
-    const formatDate = (dateString: string) => {
-        const date = new Date(dateString);
-        const now = new Date();
-        const diffMs = now.getTime() - date.getTime();
-        const diffMins = Math.floor(diffMs / 60000);
-        const diffHours = Math.floor(diffMins / 60);
-
-        if (diffMins < 1) return "Just now";
-        if (diffMins < 60) return `${diffMins}m ago`;
-        if (diffHours < 24) return `${diffHours}h ago`;
-
-        return date.toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-        });
-    };
-
     if (isPending) {
-        return <CircularProgress sx={{ mt: 4 }} />;
+        return <LiveGamesSkeleton />;
     }
 
     if (error) {
         return (
-            <Container>
-                <Alert severity="error" variant="standard">
-                    Failed to load live games. Please try again later.
-                </Alert>
-            </Container>
+            <Alert
+                severity="error"
+                variant="standard"
+                sx={{ maxWidth: 480, mx: "auto", mt: 4 }}
+            >
+                Failed to load live games. Please try again later.
+            </Alert>
         );
     }
 
     return (
-        <Container>
-            <Stack>
-                <Typography variant="h1">Live {getGameVariantString(gameVariant)} Games</Typography>
-
-                {liveGames.length === 0 ? (
-                    <Alert severity="info" variant="standard">
+        <>
+            {liveGames.length === 0 ? (
+                    <Alert
+                        severity="info"
+                        variant="standard"
+                        sx={{ maxWidth: 480, mx: "auto", width: "100%", mt: 2 }}
+                    >
                         No live games at the moment.
                     </Alert>
                 ) : (
-                    <Grid container spacing={3}>
+                    <Box sx={gameSummaryGrid}>
                         {liveGames.map((game) => (
-                            <Grid size={{ xs: 12, md: 6 }} key={game.id}>
-                                <Card
-                                    sx={{
-                                        display: "flex",
-                                        flexDirection: "column",
-                                        ...responsiveCardHover,
-                                    }}
-                                >
-                                    <CardActionArea
-                                        component={Link}
-                                        to={`/games/${gameVariant}/${game.id}`}
-                                        sx={{
-                                            display: "flex",
-                                            flexDirection: "column",
-                                            alignItems: "stretch",
-                                            flexGrow: 1,
-                                        }}
-                                    >
-                                        <CardHeader
-                                            title={
-                                                <Box
-                                                    sx={{
-                                                        display: "flex",
-                                                        alignItems: "center",
-                                                        justifyContent: "space-between",
-                                                        flexWrap: "wrap",
-                                                    }}
-                                                >
-                                                    <Typography variant="h6" component="div">
-                                                        {getGameVariantString(
-                                                            gameVariant,
-                                                            game.type,
-                                                        )}{" "}
-                                                        #{game.id}
-                                                    </Typography>
-                                                    <Chip
-                                                        icon={<AccessTimeIcon />}
-                                                        label={gameRoundString(game, gameVariant)}
-                                                        color="primary"
-                                                        size="small"
-                                                        variant="outlined"
-                                                    />
-                                                </Box>
-                                            }
-                                            subheader={
-                                                <Box
-                                                    sx={{
-                                                        display: "flex",
-                                                        alignItems: "center",
-                                                        gap: 0.5,
-                                                        mt: 1,
-                                                    }}
-                                                >
-                                                    <CalendarTodayIcon fontSize="small" />
-                                                    <Typography variant="caption">
-                                                        {formatDate(game.createdAt)}
-                                                    </Typography>
-                                                </Box>
-                                            }
-                                            sx={{
-                                                bgcolor: "action.hover",
-                                                "& .MuiCardHeader-subheader": {
-                                                    color: "text.secondary",
-                                                },
-                                            }}
-                                        />
-                                        <CardContent sx={{ flexGrow: 1 }}>
-                                            <GameSummaryBody
-                                                game={game}
-                                                gameVariant={gameVariant}
-                                            />
-                                        </CardContent>
-                                    </CardActionArea>
-                                </Card>
-                            </Grid>
+                            <GameSummaryCard
+                                key={game.id}
+                                variant="live"
+                                game={game}
+                                gameVariant={gameVariant}
+                                chipLabel={gameRoundString(game, gameVariant)}
+                                timeText={formatRelativeTime(game.createdAt)}
+                            />
                         ))}
-                    </Grid>
+                    </Box>
                 )}
-            </Stack>
-        </Container>
+        </>
     );
 };

--- a/frontend/src/game/common/GameSectionHeader.tsx
+++ b/frontend/src/game/common/GameSectionHeader.tsx
@@ -1,0 +1,29 @@
+import { Stack, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+
+// Shared header row for the Games page sections (live games / logs): an h1
+// title on the left and an optional control on the right, stacking on mobile.
+// Pass `onClick` to make the whole row a toggle (e.g. collapsible logs).
+const GameSectionHeader = ({
+    title,
+    onClick,
+    children,
+}: {
+    title: string;
+    onClick?: () => void;
+    children?: ReactNode;
+}) => (
+    <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={2}
+        alignItems={{ xs: "flex-start", sm: "center" }}
+        justifyContent="space-between"
+        onClick={onClick}
+        sx={onClick ? { cursor: "pointer", userSelect: "none" } : undefined}
+    >
+        <Typography variant="h1">{title}</Typography>
+        {children}
+    </Stack>
+);
+
+export default GameSectionHeader;

--- a/frontend/src/game/common/GameSummaryBody.tsx
+++ b/frontend/src/game/common/GameSummaryBody.tsx
@@ -1,6 +1,10 @@
-import { Box, Grid, Typography } from "@mui/material";
+import { Box, Chip, Divider, Stack, Typography, alpha } from "@mui/material";
 import { getScoresWithPlayers } from "@/common/Utils";
 import type { Game, GameVariant } from "@/types";
+import { eyebrowLabel } from "@/theme/utils";
+import { placeColor, placeLabel } from "./placement";
+
+const columnTitleSx = { ...eyebrowLabel, mb: 0.5 } as const;
 
 const GameSummaryBody = <T extends GameVariant>({
     game,
@@ -9,46 +13,152 @@ const GameSummaryBody = <T extends GameVariant>({
     game: Game<T>;
     gameVariant: T;
 }) => {
+    const sorted = getScoresWithPlayers(game, gameVariant).sort((a, b) => b.score - a.score);
+    const hasElo = sorted.some((s) => s.eloDelta !== undefined);
+
+    const ROW_H = 46;
+
     return (
-        <Grid container spacing={1.5}>
-            {getScoresWithPlayers(game, gameVariant)
-                .sort((a, b) => b.score - a.score)
-                .map((score, idx) => (
-                    <Grid size={6} key={idx}>
+        <Box sx={{ display: "flex", gap: 1.25, alignItems: "flex-start" }}>
+            {/* Name + score box */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography sx={{ ...columnTitleSx, textAlign: "center" }}>Score</Typography>
+                <Stack
+                    divider={<Divider sx={{ borderColor: "divider", opacity: 0.5 }} />}
+                    sx={{
+                        borderRadius: 1.5,
+                        border: "1px solid",
+                        borderColor: "divider",
+                        bgcolor: "background.default",
+                        overflow: "hidden",
+                    }}
+                >
+                {sorted.map((score, idx) => {
+                    const colors = placeColor(idx);
+                    return (
                         <Box
+                            key={idx}
                             sx={{
                                 display: "flex",
-                                justifyContent: "space-between",
-                                py: 1,
-                                px: 1.5,
-                                bgcolor: "background.default",
-                                borderRadius: 1,
-                                border: 1,
-                                borderColor: "divider",
+                                alignItems: "center",
+                                gap: 1,
+                                px: 1.25,
+                                minHeight: ROW_H,
                             }}
                         >
-                            <Typography variant="body2">
-                                {mapIndextoPlace(idx)} - {score.username}
+                            <Typography
+                                variant="caption"
+                                sx={{
+                                    fontWeight: 700,
+                                    width: 28,
+                                    flexShrink: 0,
+                                    color: colors.text,
+                                    fontSize: "0.9rem",
+                                }}
+                            >
+                                {placeLabel(idx)}
                             </Typography>
-                            <Typography variant="body2">{score.score}</Typography>
+                            <Divider
+                                orientation="vertical"
+                                flexItem
+                                sx={{ borderColor: "divider", opacity: 0.5, my: 1 }}
+                            />
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    flex: 1,
+                                    textAlign: "left",
+                                    fontSize: "1.05rem",
+                                    fontWeight: 600,
+                                    color: "text.primary",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap",
+                                }}
+                            >
+                                {score.username}
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    fontWeight: 650,
+                                    fontVariantNumeric: "tabular-nums",
+                                    color: "text.primary",
+                                    fontSize: "1.05rem",
+                                    minWidth: 64,
+                                    textAlign: "right",
+                                    flexShrink: 0,
+                                    p: "1px",
+                                }}
+                            >
+                                {score.score.toLocaleString()}
+                            </Typography>
                         </Box>
-                    </Grid>
-                ))}
-        </Grid>
-    );
-};
+                    );
+                    })}
+                </Stack>
+            </Box>
 
-const mapIndextoPlace = (idx: number) => {
-    switch (idx) {
-        case 0:
-            return "1st";
-        case 1:
-            return "2nd";
-        case 2:
-            return "3rd";
-        default:
-            return `${idx + 1}th`;
-    }
+            {/* Separated elo-change column — its own subtle panel */}
+            {hasElo && (
+                <Box sx={{ flexShrink: 0 }}>
+                    <Typography sx={{ ...columnTitleSx, textAlign: "center" }}>ELO Change</Typography>
+                    <Stack
+                        divider={<Divider sx={{ borderColor: "divider", opacity: 0.5 }} />}
+                        sx={{
+                            borderRadius: 1.5,
+                            border: "1px solid",
+                            borderColor: "divider",
+                            bgcolor: "background.default",
+                            overflow: "hidden",
+                        }}
+                    >
+                        {sorted.map((score, idx) => (
+                            <Box
+                                key={idx}
+                                sx={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    minHeight: ROW_H,
+                                    px: 1.25,
+                                }}
+                            >
+                                {score.eloDelta !== undefined ? (
+                                    <Chip
+                                        size="small"
+                                        label={`${score.eloDelta > 0 ? "+" : ""}${score.eloDelta.toFixed(2)}`}
+                                        sx={(t) => {
+                                            const main =
+                                                score.eloDelta! > 0
+                                                    ? t.palette.success.main
+                                                    : score.eloDelta! < 0
+                                                      ? t.palette.error.main
+                                                      : t.palette.text.disabled;
+                                            return {
+                                                width: 92,
+                                                height: ROW_H - 10,
+                                                borderRadius: 1.5,
+                                                fontWeight: 700,
+                                                fontSize: "1rem",
+                                                fontVariantNumeric: "tabular-nums",
+                                                color: main,
+                                                bgcolor: alpha(main, 0.16),
+                                                border: "none",
+                                                "& .MuiChip-label": { px: 1, width: "100%", textAlign: "center" },
+                                            };
+                                        }}
+                                    />
+                                ) : (
+                                    <Box sx={{ width: 92, height: ROW_H - 10 }} />
+                                )}
+                            </Box>
+                        ))}
+                    </Stack>
+                </Box>
+            )}
+        </Box>
+    );
 };
 
 export default GameSummaryBody;

--- a/frontend/src/game/common/GameSummaryCard.tsx
+++ b/frontend/src/game/common/GameSummaryCard.tsx
@@ -1,0 +1,211 @@
+import {
+    Box,
+    Card,
+    CardActionArea,
+    CardContent,
+    CardHeader,
+    Chip,
+    Typography,
+    Tooltip,
+} from "@mui/material";
+import { Link } from "react-router-dom";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import GameSummaryBody from "./GameSummaryBody";
+import { getGameVariantString } from "@/common/Utils";
+import type { GameVariant, Game } from "@/types";
+import { responsiveCardHover } from "@/theme/utils";
+import { pulse } from "@/theme/animations";
+
+// Shared responsive grid for laying out GameSummaryCards. Snaps to two (or
+// more) columns when the container is wide enough for another ≥360px card,
+// otherwise falls back to a single column — driven by available width, not
+// viewport breakpoints.
+export const gameSummaryGrid = {
+    display: "grid",
+    gap: 3,
+    // Cap the layout at two cards per row: a single column on narrow
+    // screens, two equal columns once there's room.
+    gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+} as const;
+
+// Shared header text sizing — identical across both variants. Text scales
+// with the card's own width (cqi units) and truncates as a last resort, so
+// nothing is ever clipped off.
+const TITLE_FONT_SIZE = "clamp(0.8rem, 4cqi, 1.25rem)";
+const TIME_ICON_FONT_SIZE = "1rem";
+const TIME_FONT_SIZE = "clamp(0.65rem, 2.4cqi, 0.7rem)";
+
+// Per-variant differences: whether the live pulse dot is shown and the scale
+// of the round/type chip.
+const VARIANT_STYLES = {
+    live: {
+        liveIndicator: true,
+        chipHeight: 30,
+        chipFontSize: "clamp(0.72rem, 3cqi, 1rem)",
+        chipTabularNums: true,
+    },
+    log: {
+        liveIndicator: false,
+        chipHeight: 45,
+        chipFontSize: "clamp(0.85rem, 3.5cqi, 1.1rem)",
+        chipTabularNums: false,
+    },
+} as const;
+
+interface GameSummaryCardProps<T extends GameVariant> {
+    game: Game<T>;
+    gameVariant: T;
+    variant: "live" | "log";
+    chipLabel: React.ReactNode;
+    timeText: React.ReactNode;
+}
+
+const GameSummaryCard = <T extends GameVariant>({
+    game,
+    gameVariant,
+    variant,
+    chipLabel,
+    timeText,
+}: GameSummaryCardProps<T>) => {
+    const s = VARIANT_STYLES[variant];
+
+    return (
+        <Card
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                // Establish a container so header text can scale with the
+                // card's width (cqi units), not the viewport.
+                containerType: "inline-size",
+                ...responsiveCardHover,
+                // Keep the gradient/shadow/border hover effects
+                // but remove the upward lift (translateY).
+                "&:hover": {
+                    transform: "none",
+                    boxShadow: { xs: "none", sm: "var(--mui-palette-appShadow-card)" },
+                    borderColor: "primary.light",
+                    "&::after": { transform: "scaleX(1)" },
+                },
+            }}
+        >
+            <CardActionArea
+                component={Link}
+                to={`/games/${gameVariant}/${game.id}`}
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "stretch",
+                    flexGrow: 1,
+                }}
+            >
+                <CardHeader
+                    title={
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                flexWrap: "nowrap",
+                                gap: 1,
+                            }}
+                        >
+                            <Box
+                                sx={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 1,
+                                    minWidth: 0,
+                                }}
+                            >
+                                {s.liveIndicator && (
+                                    <Box
+                                        sx={{
+                                            width: 9,
+                                            height: 9,
+                                            borderRadius: "50%",
+                                            bgcolor: "primary.main",
+                                            flexShrink: 0,
+                                            animation: `${pulse} 1.6s ease-in-out infinite`,
+                                            "@media (prefers-reduced-motion: reduce)": {
+                                                animation: "none",
+                                            },
+                                        }}
+                                    />
+                                )}
+                                <Typography
+                                    variant="h6"
+                                    component="div"
+                                    noWrap
+                                    sx={{
+                                        fontSize: TITLE_FONT_SIZE,
+                                        fontWeight: 700,
+                                        minWidth: 0,
+                                    }}
+                                >
+                                    {getGameVariantString(gameVariant, game.type)} #{game.id}
+                                </Typography>
+                                <Tooltip title={new Date(game.createdAt).toLocaleString()} arrow>
+                                    <Box
+                                        sx={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            gap: 0.5,
+                                            color: "text.secondary",
+                                            flexShrink: 0,
+                                        }}
+                                    >
+                                        <AccessTimeIcon sx={{ fontSize: TIME_ICON_FONT_SIZE }} />
+                                        <Typography
+                                            variant="body2"
+                                            sx={{ whiteSpace: "nowrap", fontSize: TIME_FONT_SIZE }}
+                                        >
+                                            {timeText}
+                                        </Typography>
+                                    </Box>
+                                </Tooltip>
+                            </Box>
+                            <Chip
+                                label={chipLabel}
+                                size="medium"
+                                variant="filled"
+                                sx={{
+                                    height: s.chipHeight,
+                                    flexShrink: 0,
+                                    fontSize: s.chipFontSize,
+                                    fontWeight: 600,
+                                    letterSpacing: "0.04em",
+                                    ...(s.chipTabularNums && { fontVariantNumeric: "tabular-nums" }),
+                                    border: "none",
+                                    bgcolor: "var(--mui-palette-accentTint-row)",
+                                    color: "primary.light",
+                                    "& .MuiChip-label": { px: { xs: 1, sm: 1.75 } },
+                                }}
+                            />
+                        </Box>
+                    }
+                    sx={{
+                        bgcolor: "action.hover",
+                        // Allow the title content to shrink below its intrinsic
+                        // width so it never pushes the chip off the right edge.
+                        "& .MuiCardHeader-content": {
+                            minWidth: 0,
+                            overflow: "hidden",
+                        },
+                    }}
+                />
+                <CardContent
+                    sx={{
+                        flexGrow: 1,
+                        px: 1,
+                        pt: 1,
+                        "&:last-child": { pb: 1 },
+                    }}
+                >
+                    <GameSummaryBody game={game} gameVariant={gameVariant} />
+                </CardContent>
+            </CardActionArea>
+        </Card>
+    );
+};
+
+export default GameSummaryCard;

--- a/frontend/src/game/common/placement.ts
+++ b/frontend/src/game/common/placement.ts
@@ -1,0 +1,38 @@
+import { palette, placement } from "@/theme/tokens";
+
+/** "1st" / "2nd" / "3rd" / "4th" from a 0-based place index. */
+export const placeLabel = (idx: number) => {
+    switch (idx) {
+        case 0:
+            return "1st";
+        case 1:
+            return "2nd";
+        case 2:
+            return "3rd";
+        default:
+            return `${idx + 1}th`;
+    }
+};
+
+/** Finishing-position colors (1st–4th) shared by the summary and live footer. */
+export const PLACE_COLORS = [
+    { bg: palette.medal.gold.bg, text: palette.medal.gold.text, border: "#F5D060" },
+    { bg: palette.medal.silver.bg, text: palette.medal.silver.text, border: "#C0C0C0" },
+    { bg: palette.medal.bronze.bg, text: palette.medal.bronze.text, border: "#CD7F32" },
+    { bg: "rgba(111,88,72,0.14)", text: placement[4], border: placement[4] },
+] as const;
+
+export const placeColor = (idx: number) => PLACE_COLORS[idx] ?? PLACE_COLORS[3];
+
+/**
+ * Ranks players by value (highest first) and returns each player's 0-based
+ * place, keyed by the player's original index. Ties resolve by original order.
+ */
+export const computePlaces = (values: number[]): number[] => {
+    const order = values.map((_, i) => i).sort((a, b) => values[b] - values[a]);
+    const places: number[] = new Array(values.length);
+    order.forEach((playerIndex, rank) => {
+        places[playerIndex] = rank;
+    });
+    return places;
+};


### PR DESCRIPTION
Merge the separate LiveGames and GameLogs views into a single /games page:
- Games.tsx composes LiveGamesSection + GameLogsSection under shared GameSectionHeader.
- LiveGames.tsx / GameLogs.tsx refactored to export those sections and share GameSummaryCard -> GameSummaryBody, with placement.ts (new) as the shared place-color/label source and Utils.formatRelativeTime for "5m ago" stamps.
- App.tsx: /games/current/{jp,hk} collapse to /games/current; /games now renders Games. (Record-game /games/create routing is migrated in the next PR.)

placement.ts is added here as an additive shared helper; the record-game flow picks it up in the following PR. Record-game code is untouched and still compiles against the existing constants.